### PR TITLE
add: マップ取得APIの実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,8 @@ build:
 
 ## 全ビルドし直して起動（キャッシュなし）
 rebuild:
-	$(DC) down
-	$(DC) build --no-cache
-	$(DC) up -d
+	$(DC) down -v
+	$(DC) up -d --build
 
 ## イメージの pull（依存イメージの更新）
 pull:

--- a/services/nutfesmap-api/204
+++ b/services/nutfesmap-api/204
@@ -1,0 +1,7 @@
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/json
+Vary: Origin
+Date: Sun, 28 Sep 2025 10:50:08 GMT
+Content-Length: 36
+
+{"message":"Internal Server Error"}

--- a/services/nutfesmap-api/api/swagger.yaml
+++ b/services/nutfesmap-api/api/swagger.yaml
@@ -642,35 +642,9 @@ components:
 
     MapCreateRequest:
       type: object
-      required:
-        - name
-        - imageData
-        - naturalWidth
-        - naturalHeight
       properties:
-        name:
-          type: string
-        imageData:
-          type: string
-          format: byte
-          description: "背景画像のbase64エンコード文字列"
-        naturalWidth:
-          type: integer
-          minimum: 1
-        naturalHeight:
-          type: integer
-          minimum: 1
         parentMapId:
           type: string
-          nullable: true
-        hasFloors:
-          type: boolean
-          default: false
-        floorCount:
-          type: integer
-          minimum: 0
-          default: 0
-          description: "hasFloors=true の場合は 1 以上を推奨"
 
     MapUpdateRequest:
       type: object
@@ -687,14 +661,6 @@ components:
         naturalHeight:
           type: integer
           minimum: 1
-        parentMapId:
-          type: string
-          nullable: true
-        hasFloors:
-          type: boolean
-        floorCount:
-          type: integer
-          minimum: 0
 
     # --- Pin関連（説明画像のbase64を追加） ---
     PinType:

--- a/services/nutfesmap-api/api/swagger.yaml
+++ b/services/nutfesmap-api/api/swagger.yaml
@@ -1,56 +1,59 @@
 openapi: 3.1.0
 info:
   title: "nutfesmap 技大祭マップ API"
-  version: "0.4.0"
+  version: "0.6.5"
   description: |
-    技大祭マップサービスAPI。
+    技大祭マップサービスAPI（Auth / Users / Maps / Floors / Pins）
 
-    ■ 現仕様
-    - 全エンドポイントは認証不要（公開）です。
-    - Auth系エンドポイントは将来利用のため仕様として残していますが、呼び出し時の認証要件はありません。
+    ■ 設計方針（DB優先）
+    - `maps` は **1行=1マップ=一意の `id`（PK）**。
+    - 「同じMAP IDで全階を扱う」は、**root（親）Mapの `id` をグループID** として用い、
+      各階の `parent_map_id` に **rootの `id`** を格納（各階自身の `id` はユニーク）。
+        - 例）root: id=`map_123`、各階は `parent_map_id=map_123` を共有。
+    - 取得は **グループID（=root.id）** を指定して **root＋全階** を一括返却（場合分け不要）。
+    - **階追加APIのリクエストは、マップ追加API（/maps POST）と完全同一**（= `MapCreateRequest`）。
+      - クライアントは `{"parentMapId": "<rootIdまたはこのpathの{mapId}>”}` **だけ**送ればよい（空のフロアを作成）。
+      - サーバは `parentMapId` が path の `{mapId}` と不一致でも **path側の rootId を優先** して処理する。
 
 servers:
   - url: "http://localhost:8080"
     description: "ローカル開発用サーバ"
   - url: "http://localhost:8080/api"
-    description: "/api プレフィックスを付ける構成の場合（必要に応じてパスも合わせる）"
+    description: "/api プレフィックス構成"
 
 tags:
   - name: "Auth"
-    description: "認証関連API（現在は未使用だが仕様は保持）"
+    description: "認証関連API"
   - name: "Users"
-    description: "ユーザー関連API"
+    description: "ユーザー管理API"
   - name: "Maps"
-    description: "地図（背景画像メタ／階層: campus→area→floor）関連API"
+    description: "地図メタ／階（フロア）スタック操作"
   - name: "Pins"
-    description: "地図上のピン（企画・エリア選択など）関連API"
+    description: "ピン（正規化座標）"
 
 paths:
+  # ───────────── Auth ─────────────
   /auth/login:
     post:
       tags: ["Auth"]
       summary: "ユーザーログイン"
       description: |
-        ユーザーを認証し、アクセスJWTを返却。リフレッシュトークンは HttpOnly Cookie `rt` に設定されます。
-        現仕様では呼び出し時の認証・CSRFチェックは不要。
+        ユーザーを認証し、アクセスJWTを返却。リフレッシュトークンは HttpOnly Cookie `rt` に設定。
       requestBody:
         required: true
         content:
           application/json:
-            schema:
-              $ref: "#/components/schemas/LoginRequest"
+            schema: { $ref: "#/components/schemas/LoginRequest" }
       responses:
         "200":
           description: "認証成功"
           headers:
             Set-Cookie:
               description: "HttpOnly refresh token cookie (rt)"
-              schema:
-                type: string
+              schema: { type: string }
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/TokenResponse"
+              schema: { $ref: "#/components/schemas/TokenResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/UnauthorizedError" }
         "409": { $ref: "#/components/responses/Conflict" }
@@ -60,21 +63,17 @@ paths:
     post:
       tags: ["Auth"]
       summary: "アクセストークン再発行"
-      description: |
-        有効なリフレッシュトークンCookieを用いてアクセストークンを再発行し、リフレッシュトークンもローテーションします。
-        現仕様では呼び出し時の認証・CSRFチェックは不要。
+      description: "有効なRT Cookieを用いてATを再発行し、RTもローテーションする。"
       responses:
         "200":
           description: "再発行成功"
           headers:
             Set-Cookie:
               description: "Rotated HttpOnly refresh token cookie (rt)"
-              schema:
-                type: string
+              schema: { type: string }
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/TokenResponse"
+              schema: { $ref: "#/components/schemas/TokenResponse" }
         "401": { $ref: "#/components/responses/UnauthorizedError" }
         "500": { $ref: "#/components/responses/ServerError" }
 
@@ -82,51 +81,44 @@ paths:
     post:
       tags: ["Auth"]
       summary: "ログアウト"
-      description: |
-        リフレッシュトークンを無効化し、Cookieを削除します。
-        現仕様では呼び出し時の認証・CSRFチェックは不要。
+      description: "RTを無効化し、Cookieを削除する。"
       responses:
         "204":
           description: "ログアウト成功（No Content）"
           headers:
             Set-Cookie:
               description: "クリアされたリフレッシュトークンCookie"
-              schema:
-                type: string
+              schema: { type: string }
         "500": { $ref: "#/components/responses/ServerError" }
 
   /auth/csrf:
     get:
       tags: ["Auth"]
       summary: "CSRFトークン取得"
-      description: "CSRFトークンを返却（現仕様では必須ではありません）。"
       responses:
         "200":
           description: "取得成功"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/CsrfResponse"
+              schema: { $ref: "#/components/schemas/CsrfResponse" }
         "500": { $ref: "#/components/responses/ServerError" }
 
+  # ───────────── Users ─────────────
   /users/register:
     post:
       tags: ["Users"]
       summary: "ユーザー登録"
-      description: "新規ユーザー登録（認証・CSRF不要）。"
       requestBody:
         required: true
         content:
           application/json:
-            schema:
-              $ref: "#/components/schemas/UserCreateRequest"
+            schema: { $ref: "#/components/schemas/UserCreateRequest" }
       responses:
         "201":
           description: "登録成功"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/UserResponse"
+              schema: { $ref: "#/components/schemas/UserResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/ServerError" }
@@ -134,14 +126,13 @@ paths:
   /users/me:
     get:
       tags: ["Users"]
-      summary: "自分のユーザー情報取得（認証不要のダミー想定可）"
+      summary: "自分のユーザー情報取得"
       responses:
         "200":
           description: "取得成功"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/UserResponse"
+              schema: { $ref: "#/components/schemas/UserResponse" }
         "401": { $ref: "#/components/responses/UnauthorizedError" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
@@ -151,19 +142,16 @@ paths:
       tags: ["Users"]
       summary: "ユーザー情報取得"
       parameters:
-        - name: "id"
-          in: "path"
+        - name: id
+          in: path
           required: true
-          description: "ユーザー識別子"
-          schema:
-            type: string
+          schema: { type: string }
       responses:
         "200":
           description: "取得成功"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/UserResponse"
+              schema: { $ref: "#/components/schemas/UserResponse" }
         "401": { $ref: "#/components/responses/UnauthorizedError" }
         "403": { $ref: "#/components/responses/ForbiddenError" }
         "404": { $ref: "#/components/responses/NotFound" }
@@ -172,27 +160,23 @@ paths:
   /users/update/{id}:
     put:
       tags: ["Users"]
-      summary: "ユーザー情報更新（認証・CSRF不要）"
+      summary: "ユーザー情報更新"
       parameters:
-        - name: "id"
-          in: "path"
+        - name: id
+          in: path
           required: true
-          description: "ユーザー識別子"
-          schema:
-            type: string
+          schema: { type: string }
       requestBody:
         required: true
         content:
           application/json:
-            schema:
-              $ref: "#/components/schemas/UserUpdateRequest"
+            schema: { $ref: "#/components/schemas/UserUpdateRequest" }
       responses:
         "200":
           description: "更新成功"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/UserResponse"
+              schema: { $ref: "#/components/schemas/UserResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/UnauthorizedError" }
         "403": { $ref: "#/components/responses/ForbiddenError" }
@@ -202,36 +186,29 @@ paths:
   /users/delete/{id}:
     delete:
       tags: ["Users"]
-      summary: "ユーザー削除（認証・CSRF不要）"
+      summary: "ユーザー削除"
       parameters:
-        - name: "id"
-          in: "path"
+        - name: id
+          in: path
           required: true
-          description: "ユーザー識別子"
-          schema:
-            type: string
+          schema: { type: string }
       responses:
-        "204":
-          description: "削除成功"
+        "204": { description: "削除成功" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/UnauthorizedError" }
         "403": { $ref: "#/components/responses/ForbiddenError" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
 
+  # ───────────── Maps（Index） ─────────────
   /maps/index:
     get:
       tags: ["Maps"]
-      summary: "Index Map取得（親なしMapのみ）"
-      description: "parentMapId が null の Map を返す（キャンパスなど最上位）。画面初期表示用。"
+      summary: "Index Map取得（親なしMapのみ＝root）"
+      description: "parentMapId が null の Map（root）一覧。"
       responses:
         "200":
           description: "取得成功"
-          headers:
-            ETag:
-              schema:
-                type: string
-              description: "キャッシュ用ETag"
           content:
             application/json:
               schema:
@@ -239,114 +216,159 @@ paths:
                 properties:
                   items:
                     type: array
-                    items:
-                      $ref: "#/components/schemas/MapResponse"
+                    items: { $ref: "#/components/schemas/MapResponse" }
 
+  # ───────────── Maps（作成） ─────────────
   /maps:
     post:
       tags: ["Maps"]
-      summary: "地図メタ作成（管理者）"
-      description: "背景画像（base64）と自然サイズ（natural size）を登録する。"
+      summary: "マップ作成（root または floor）"
+      description: |
+        - `parentMapId=null` で **root** を作成。
+        - `parentMapId=<rootId>` で **floor** を1つ追加（空のマップ）。  
+          追加時は root の `has_floors=true`、`floor_count` を +1。
       requestBody:
         required: true
         content:
           application/json:
-            schema:
-              $ref: "#/components/schemas/MapCreateRequest"
+            schema: { $ref: "#/components/schemas/MapCreateRequest" }
       responses:
         "201":
-          description: "作成成功"
+          description: "作成成功（単体Map）"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/MapResponse"
+              schema: { $ref: "#/components/schemas/MapResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
 
+  # ───────────── Maps（取得／更新／削除） ─────────────
   /maps/{mapId}:
     get:
       tags: ["Maps"]
-      summary: "地図メタ取得（直下の children 付き）"
+      summary: "マップ取得（“同じMAP ID”=グループの全件を一括）"
+      description: |
+        - `mapId` が **root のID** の場合：その root と `parent_map_id=mapId` の全階をまとめて返す。
+        - `mapId` が **階のID** の場合：その階の `parent_map_id`（=root.id）を特定して同様に返す。
+        - **常にグループ全体（root＋全階）** を返す。余計なクエリは不要。
       parameters:
-        - in: "path"
-          name: "mapId"
+        - in: path
+          name: mapId
           required: true
-          schema:
-            type: string
+          schema: { type: string }
       responses:
         "200":
-          description: "取得成功"
+          description: "取得成功（階スタック）"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/MapResponse"
+              schema: { $ref: "#/components/schemas/FloorStackResponse" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
+
     patch:
       tags: ["Maps"]
-      summary: "地図メタ更新（管理者）"
-      description: "必要フィールドのみ部分更新。"
+      summary: "マップ部分更新（単体Map）"
       parameters:
-        - in: "path"
-          name: "mapId"
+        - in: path
+          name: mapId
           required: true
-          schema:
-            type: string
+          schema: { type: string }
       requestBody:
         required: true
         content:
           application/json:
-            schema:
-              $ref: "#/components/schemas/MapUpdateRequest"
+            schema: { $ref: "#/components/schemas/MapUpdateRequest" }
       responses:
         "200":
-          description: "更新成功"
+          description: "更新成功（単体Map）"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/MapResponse"
+              schema: { $ref: "#/components/schemas/MapResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
+
     delete:
       tags: ["Maps"]
-      summary: "地図メタ削除（再帰的に子マップ・ピンも削除）"
+      summary: "マップ削除（再帰）"
       description: |
-        指定した Map を **ON DELETE CASCADE** 相当で削除します。
-        その配下の **子マップ（再帰）** と **各マップに紐づく全ピン** も同時に削除します。
-        実装はDBの外部キー `ON DELETE CASCADE` またはアプリ層の再帰削除のいずれでも可。
+        指定 `mapId` の単体Mapを削除。  
+        root を削除した場合は、その `parent_map_id=root.id` の全floorも合わせて削除（CASCADE相当）。  
+        floor を削除した場合は、root の `floor_count` を -1、0 なら `has_floors=false`。
       parameters:
-        - in: "path"
-          name: "mapId"
+        - in: path
+          name: mapId
           required: true
-          schema:
-            type: string
+          schema: { type: string }
       responses:
-        "204":
-          description: "削除成功（No Content。配下も含めて削除済み）"
+        "204": { description: "削除成功（No Content）" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
 
+  # ───────────── Floors（追加／最上階削除） ─────────────
+  /maps/{mapId}/floors:
+    post:
+      tags: ["Maps"]
+      summary: "階追加（リクエストは /maps POST と同一：MapCreateRequest）"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/MapCreateRequest" }
+            examples:
+              onlyParent:
+                summary: "ParentMapIDだけ渡す"
+                value: { parentMapId: "map_123" }
+              withName:
+                summary: "任意で階の表示名を指定"
+                value: { parentMapId: "map_123", name: "講義棟 4F" }
+      responses:
+        "201":
+          description: "作成成功（作成した階＋最新スタックを返す）"
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/FloorCreateResult" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/ServerError" }
+
+  /maps/{mapId}/floors/{floorIndex}:
+    delete:
+      tags: ["Maps"]
+      summary: "階削除（最上階のみ削除可）"
+      description: |
+        - `floorIndex` は **1..floor_count**。  
+        - **現在の `floor_count` と同じ値** のときのみ削除可（= 最上階のみ）。  
+        - 削除後は root の `floor_count` を -1、0 なら `has_floors=false`。
+      parameters:
+        - in: path
+          name: mapId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: floorIndex
+          required: true
+          schema: { type: integer, minimum: 1 }
+      responses:
+        "204": { description: "削除成功（No Content）" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/ServerError" }
+
+  # ───────────── Pins ─────────────
   /maps/{mapId}/pins:
     get:
       tags: ["Pins"]
-      summary: "ピン一覧取得（該当Mapの全件）"
-      description: |
-        指定 Map に属する全ピンを返す。正規化座標（0〜1）の相対座標を返すため、
-        クライアントは表示時に現在の画像サイズへ射影すること。
+      summary: "指定Mapのピン一覧（単一Mapに属するピン）"
       parameters:
-        - in: "path"
-          name: "mapId"
+        - in: path
+          name: mapId
           required: true
-          schema:
-            type: string
+          schema: { type: string }
       responses:
         "200":
-          description: "取得成功（全件）"
-          headers:
-            ETag:
-              schema:
-                type: string
+          description: "取得成功"
           content:
             application/json:
               schema:
@@ -354,27 +376,31 @@ paths:
                 properties:
                   items:
                     type: array
-                    items:
-                      $ref: "#/components/schemas/PinResponse"
+                    items: { $ref: "#/components/schemas/PinResponse" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
+
     post:
       tags: ["Pins"]
-      summary: "ピン作成（管理者/担当者）"
+      summary: "ピン作成（単一Mapに紐づけ）"
+      parameters:
+        - in: path
+          name: mapId
+          required: true
+          schema: { type: string }
       requestBody:
         required: true
         content:
           application/json:
-            schema:
-              $ref: "#/components/schemas/PinCreateRequest"
+            schema: { $ref: "#/components/schemas/PinCreateRequest" }
       responses:
         "201":
           description: "作成成功"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/PinResponse"
+              schema: { $ref: "#/components/schemas/PinResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
 
   /pins/{pinId}:
@@ -382,57 +408,52 @@ paths:
       tags: ["Pins"]
       summary: "ピン詳細取得"
       parameters:
-        - in: "path"
-          name: "pinId"
+        - in: path
+          name: pinId
           required: true
-          schema:
-            type: string
+          schema: { type: string }
       responses:
         "200":
           description: "取得成功"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/PinResponse"
+              schema: { $ref: "#/components/schemas/PinResponse" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
+
     patch:
       tags: ["Pins"]
-      summary: "ピン情報更新（名称/説明/カテゴリ/ステータス等）"
+      summary: "ピン更新"
       parameters:
-        - in: "path"
-          name: "pinId"
+        - in: path
+          name: pinId
           required: true
-          schema:
-            type: string
+          schema: { type: string }
       requestBody:
         required: true
         content:
           application/json:
-            schema:
-              $ref: "#/components/schemas/PinUpdateRequest"
+            schema: { $ref: "#/components/schemas/PinUpdateRequest" }
       responses:
         "200":
           description: "更新成功"
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/PinResponse"
+              schema: { $ref: "#/components/schemas/PinResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
+
     delete:
       tags: ["Pins"]
-      summary: "ピン削除（管理者）"
+      summary: "ピン削除"
       parameters:
-        - in: "path"
-          name: "pinId"
+        - in: path
+          name: pinId
           required: true
-          schema:
-            type: string
+          schema: { type: string }
       responses:
-        "204":
-          description: "削除成功"
+        "204": { description: "削除成功" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
 
@@ -453,251 +474,275 @@ components:
 
   responses:
     BadRequest:
-      description: "入力値不正エラー"
+      description: "入力値不正"
       content:
         application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
     UnauthorizedError:
-      description: "認証情報不正エラー（将来用。現時点では未使用）"
+      description: "認証情報不正"
       content:
         application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
     ForbiddenError:
-      description: "権限不足エラー（将来用。現時点では未使用）"
+      description: "権限不足"
       content:
         application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
     Conflict:
-      description: "競合エラー"
+      description: "競合（例: 最上階以外の削除）"
       content:
         application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
     NotFound:
       description: "対象が存在しない"
       content:
         application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
     ServerError:
       description: "サーバ内部エラー"
       content:
         application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
 
   schemas:
+    # ── 共通 ──
     ErrorResponse:
       type: object
+      required: [message]
       properties:
         message:
           type: string
-      required:
-        - message
-
-    PageInfo:
-      type: object
-      properties:
-        page:
-          type: integer
-          example: 1
-        perPage:
-          type: integer
-          example: 50
-        total:
-          type: integer
-          example: 123
-      required:
-        - page
-        - perPage
-        - total
+          example: "validation error"
 
     CsrfResponse:
       type: object
+      required: [csrf_token]
       properties:
         csrf_token:
           type: string
-      required:
-        - csrf_token
+          example: "f02c9d2a-8f6e-4a7e-9f7b-2e8b9c8a2aa1"
 
+    # ── Auth ──
     LoginRequest:
       type: object
-      required:
-        - username
-        - password
+      required: [username, password]
       properties:
         username:
           type: string
-          description: "ログインID"
-          example: "kitano_masaki"
+          example: "kitano"
         password:
           type: string
           format: password
-          description: "ログイン用パスワード"
           example: "Passw0rd!123"
 
     TokenResponse:
       type: object
-      required:
-        - access_token
-        - access_expires_at
+      required: [access_token, access_expires_at]
       properties:
         access_token:
           type: string
           description: "アクセスJWT"
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
         access_expires_at:
           type: string
           format: date-time
-          description: "アクセスJWTの有効期限"
+          example: "2025-10-01T00:00:00Z"
 
-    # --- Map関連（imageData & floorCount、version/isActive/type なし） ---
-    MapChildRef:
+    # ── Users ──
+    UserCreateRequest:
       type: object
-      description: "子マップの軽量参照"
-      required:
-        - id
-        - name
+      required: [username, email]
+      properties:
+        username:
+          type: string
+          minLength: 3
+          maxLength: 50
+          example: "kitano"
+        email:
+          type: string
+          format: email
+          example: "kitano@example.com"
+        displayName:
+          type: string
+          maxLength: 100
+          example: "北野 正樹"
+        password:
+          type: string
+          format: password
+          example: "Passw0rd!123"
+
+    UserUpdateRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          example: "kitano+new@example.com"
+        displayName:
+          type: string
+          maxLength: 100
+          example: "北野 まさき"
+        password:
+          type: string
+          format: password
+          example: "N3wPassw0rd!456"
+
+    UserResponse:
+      type: object
+      required: [id, username, email, createdAt, modifiedAt]
       properties:
         id:
           type: string
-          example: "map_01JCHILD01"
-        name:
+          example: "user_01ABCDEF"
+        username:
           type: string
-          example: "講義棟エリア"
-        hasFloors:
-          type: boolean
-          description: "その配下に floor を持つか"
-          example: true
-        floorCount:
-          type: integer
-          minimum: 0
-          description: "フロア数（floor 未導入の階層では 0 もあり得る）"
-          example: 3
+          example: "kitano"
+        email:
+          type: string
+          example: "kitano@example.com"
+        displayName:
+          type: string
+          example: "北野 正樹"
+        createdAt:
+          type: string
+          format: date-time
+          example: "2025-09-01T12:00:00Z"
+        modifiedAt:
+          type: string
+          format: date-time
+          example: "2025-09-15T09:30:00Z"
 
+    # ── Maps/Floors ──
     MapResponse:
       type: object
       required:
-        - id
-        - name
-        - imageData
-        - naturalWidth
-        - naturalHeight
-        - parentMapId
-        - hasFloors
-        - floorCount
-        - childrenCount
-        - children
-        - createdAt
-        - modifiedAt
+        [ id, name, imageData, naturalWidth, naturalHeight,
+          parentMapId, hasFloors, floorCount, createdAt, modifiedAt ]
       properties:
         id:
           type: string
-          example: "map_01HZXABCDE"
+          example: "map_123"
         name:
           type: string
-          example: "2025 技大祭メインマップ"
+          example: "講義棟エリア（root または floor）"
         imageData:
           type: string
           format: byte
-          description: "背景画像のbase64エンコード文字列"
+          nullable: true
+          description: "背景画像のbase64"
+          example: null
         naturalWidth:
           type: integer
-          minimum: 1
+          minimum: 0
           example: 4096
         naturalHeight:
           type: integer
-          minimum: 1
+          minimum: 0
           example: 3072
         parentMapId:
           type: string
           nullable: true
-          description: "親マップのID（area→campus, floor→area）"
+          description: "rootはnull、floorはroot.id（=同じMAP IDグループ）"
+          example: null
         hasFloors:
           type: boolean
-          description: "このマップが複数フロアを持つか"
+          description: "root 側の集約フラグ"
           example: true
         floorCount:
           type: integer
           minimum: 0
-          description: "階数（hasFloors=true の場合は 1 以上）"
+          description: "root 側の集約値"
           example: 3
-        childrenCount:
-          type: integer
-          description: "直下の子マップ数"
-          example: 3
-        children:
-          type: array
-          description: "直下の子マップ一覧（常に同梱。空配列の可能性あり）"
-          items:
-            $ref: "#/components/schemas/MapChildRef"
         createdAt:
           type: string
           format: date-time
+          example: "2025-09-01T00:00:00Z"
         modifiedAt:
           type: string
           format: date-time
+          example: "2025-09-20T10:00:00Z"
 
     MapCreateRequest:
       type: object
+      required: [parentMapId]
       properties:
         parentMapId:
           type: string
+          nullable: true
+          description: "nullならroot作成。root.idを指定すると“空の階”を1つ作成（親IDはroot.id）"
+          example: null
 
     MapUpdateRequest:
       type: object
       properties:
         name:
           type: string
+          example: "講義棟エリア（更新）"
         imageData:
           type: string
           format: byte
-          description: "背景画像のbase64エンコード文字列（差し替え時のみ）"
+          example: null
         naturalWidth:
           type: integer
-          minimum: 1
+          minimum: 0
+          example: 5000
         naturalHeight:
           type: integer
+          minimum: 0
+          example: 3500
+
+    FloorItem:
+      type: object
+      required: [floorIndex, map]
+      properties:
+        floorIndex:
+          type: integer
           minimum: 1
+          description: "1=1F..作成時刻昇順で連番付与"
+          example: 2
+        map:
+          $ref: "#/components/schemas/MapResponse"
 
-    # --- Pin関連（説明画像のbase64を追加） ---
-    PinType:
-      type: string
-      enum: ["area_selector","exhibit","service","info"]
-      example: "area_selector"
+    FloorStackResponse:
+      type: object
+      required: [rootMapId, rootName, floorCount, items]
+      properties:
+        rootMapId:
+          type: string
+          example: "map_123"
+        rootName:
+          type: string
+          example: "講義棟エリア"
+        floorCount:
+          type: integer
+          minimum: 0
+          example: 3
+        items:
+          type: array
+          description: "1F..最上階（必要に応じ、UI側でrootも別枠表示可）"
+          items: { $ref: "#/components/schemas/FloorItem" }
 
-    PinCategory:
-      type: string
-      enum: ["food","stage","exhibition","game","service","other"]
-      example: "food"
+    FloorCreateResult:
+      type: object
+      required: [created, stack]
+      properties:
+        created:
+          $ref: "#/components/schemas/FloorItem"
+        stack:
+          $ref: "#/components/schemas/FloorStackResponse"
 
-    PinStatus:
-      type: string
-      enum: ["open","paused","closed"]
-      example: "open"
-
+    # ── Pins ──
     PinResponse:
       type: object
       required:
-        - id
-        - mapId
-        - name
-        - xNorm
-        - yNorm
-        - category
-        - status
-        - waitMinutes
-        - createdAt
-        - modifiedAt
+        [ id, mapId, name, xNorm, yNorm, category, status, waitMinutes, createdAt, modifiedAt ]
       properties:
         id:
           type: string
           example: "pin_01J0AABCDE"
         mapId:
           type: string
-          example: "map_01HZXABCDE"
+          example: "map_123"
         name:
           type: string
           example: "ラーメン研究会"
@@ -708,84 +753,105 @@ components:
           type: string
           format: byte
           nullable: true
-          description: "説明用画像のbase64エンコード文字列"
+          example: null
         type:
-          $ref: "#/components/schemas/PinType"
+          type: string
+          enum: ["area_selector","exhibit","service","info"]
+          default: "exhibit"
+          example: "exhibit"
         linkToMapId:
           type: string
           nullable: true
-          description: "type=area_selector の場合に必須。遷移先のエリア/フロアの Map ID"
+          description: "type=area_selector の場合に遷移先Map ID"
+          example: null
         xNorm:
           type: number
           format: float
           minimum: 0
           maximum: 1
-          example: 0.3125
           description: "画像左上(0,0)〜右下(1,1)の正規化X座標"
+          example: 0.3125
         yNorm:
           type: number
           format: float
           minimum: 0
           maximum: 1
-          example: 0.742
           description: "画像左上(0,0)〜右下(1,1)の正規化Y座標"
+          example: 0.742
         category:
-          $ref: "#/components/schemas/PinCategory"
+          type: string
+          enum: ["food","stage","exhibition","game","service","other"]
+          example: "food"
         status:
-          $ref: "#/components/schemas/PinStatus"
+          type: string
+          enum: ["open","paused","closed"]
+          default: "open"
+          example: "open"
         waitMinutes:
           type: integer
           minimum: 0
+          default: 0
           example: 20
         createdAt:
           type: string
           format: date-time
+          example: "2025-09-29T04:00:00Z"
         modifiedAt:
           type: string
           format: date-time
+          example: "2025-09-29T05:00:00Z"
 
     PinCreateRequest:
       type: object
-      required:
-        - name
-        - xNorm
-        - yNorm
-        - category
+      required: [name, xNorm, yNorm, category]
       properties:
         name:
           type: string
           minLength: 1
           maxLength: 100
+          example: "ラーメン研究会"
         description:
           type: string
           maxLength: 1000
+          example: "替え玉あり・スープ無くなり次第終了"
         descriptionImageData:
           type: string
           format: byte
           nullable: true
-          description: "説明用画像のbase64エンコード文字列"
+          example: null
         type:
-          $ref: "#/components/schemas/PinType"
+          type: string
+          enum: ["area_selector","exhibit","service","info"]
+          default: "exhibit"
+          example: "exhibit"
         linkToMapId:
           type: string
           nullable: true
+          example: null
         xNorm:
           type: number
           minimum: 0
           maximum: 1
+          example: 0.31
         yNorm:
           type: number
           minimum: 0
           maximum: 1
+          example: 0.74
         category:
-          $ref: "#/components/schemas/PinCategory"
+          type: string
+          enum: ["food","stage","exhibition","game","service","other"]
+          example: "food"
         status:
-          $ref: "#/components/schemas/PinStatus"
+          type: string
+          enum: ["open","paused","closed"]
           default: "open"
+          example: "open"
         waitMinutes:
           type: integer
           minimum: 0
           default: 0
+          example: 0
 
     PinUpdateRequest:
       type: object
@@ -794,42 +860,39 @@ components:
           type: string
           minLength: 1
           maxLength: 100
+          example: "ラーメン研究会（増席）"
         description:
           type: string
           maxLength: 1000
+          example: "スープ増量、提供速度改善"
         descriptionImageData:
           type: string
           format: byte
           nullable: true
-          description: "説明用画像のbase64エンコード文字列（差し替え時のみ）"
+          example: null
         type:
-          $ref: "#/components/schemas/PinType"
+          type: string
+          enum: ["area_selector","exhibit","service","info"]
+          example: "exhibit"
         linkToMapId:
           type: string
           nullable: true
+          example: null
         xNorm:
           type: number
           minimum: 0
           maximum: 1
+          example: 0.33
         yNorm:
           type: number
           minimum: 0
           maximum: 1
+          example: 0.70
         category:
-          $ref: "#/components/schemas/PinCategory"
-        status:
-          $ref: "#/components/schemas/PinStatus"
-
-    WaittimeUpdateRequest:
-      type: object
-      required:
-        - waitMinutes
-      properties:
-        waitMinutes:
-          type: integer
-          minimum: 0
-          example: 35
-        note:
           type: string
-          maxLength: 200
-          description: "運用メモ（任意、監査ログ用）"
+          enum: ["food","stage","exhibition","game","service","other"]
+          example: "food"
+        status:
+          type: string
+          enum: ["open","paused","closed"]
+          example: "open"

--- a/services/nutfesmap-api/api/swagger.yaml
+++ b/services/nutfesmap-api/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: "nutfesmap 技大祭マップ API"
-  version: "0.6.5"
+  version: "0.7.1"
   description: |
     技大祭マップサービスAPI（Auth / Users / Maps / Floors / Pins）
 
@@ -10,10 +10,11 @@ info:
     - 「同じMAP IDで全階を扱う」は、**root（親）Mapの `id` をグループID** として用い、
       各階の `parent_map_id` に **rootの `id`** を格納（各階自身の `id` はユニーク）。
         - 例）root: id=`map_123`、各階は `parent_map_id=map_123` を共有。
-    - 取得は **グループID（=root.id）** を指定して **root＋全階** を一括返却（場合分け不要）。
-    - **階追加APIのリクエストは、マップ追加API（/maps POST）と完全同一**（= `MapCreateRequest`）。
-      - クライアントは `{"parentMapId": "<rootIdまたはこのpathの{mapId}>”}` **だけ**送ればよい（空のフロアを作成）。
-      - サーバは `parentMapId` が path の `{mapId}` と不一致でも **path側の rootId を優先** して処理する。
+    - ルート（親なし）一覧は `/maps/index`。
+    - 単体の Map は `/maps/{mapId}` で取得・更新。
+    - **フロア（階）スタックの取得は `/maps/{mapId}/floors`**（`mapId` は root でも floor でも可）。
+    - **階の追加は `/maps/{mapId}/floors`（POST）**、**階の削除は `/maps/{mapId}/floors/{floorIndex}`（DELETE）**。
+    - ETag は `ID` と `ModifiedAt`（または階ごとの `ModifiedAt`）から生成し、主要レスポンスに付与。
 
 servers:
   - url: "http://localhost:8080"
@@ -97,10 +98,12 @@ paths:
       summary: "CSRFトークン取得"
       responses:
         "200":
-          description: "取得成功"
+          description: "取得成功（CSRF有効時）"
           content:
             application/json:
               schema: { $ref: "#/components/schemas/CsrfResponse" }
+        "204":
+          description: "CSRF無効時（No Content）"
         "500": { $ref: "#/components/responses/ServerError" }
 
   # ───────────── Users ─────────────
@@ -209,6 +212,10 @@ paths:
       responses:
         "200":
           description: "取得成功"
+          headers:
+            ETag:
+              description: "インデックスリストのETag（If-None-Match で条件付き GET 可）"
+              schema: { type: string, example: 'W/"8dfcd278e0..."' }
           content:
             application/json:
               schema:
@@ -225,8 +232,7 @@ paths:
       summary: "マップ作成（root または floor）"
       description: |
         - `parentMapId=null` で **root** を作成。
-        - `parentMapId=<rootId>` で **floor** を1つ追加（空のマップ）。  
-          追加時は root の `has_floors=true`、`floor_count` を +1。
+        - `parentMapId=<rootId>` で **floor** を1つ追加（空のマップ）。
       requestBody:
         required: true
         content:
@@ -235,6 +241,10 @@ paths:
       responses:
         "201":
           description: "作成成功（単体Map）"
+          headers:
+            ETag:
+              description: "作成されたMapのETag"
+              schema: { type: string, example: 'W/"a1b2c3..."' }
           content:
             application/json:
               schema: { $ref: "#/components/schemas/MapResponse" }
@@ -246,11 +256,8 @@ paths:
   /maps/{mapId}:
     get:
       tags: ["Maps"]
-      summary: "マップ取得（“同じMAP ID”=グループの全件を一括）"
-      description: |
-        - `mapId` が **root のID** の場合：その root と `parent_map_id=mapId` の全階をまとめて返す。
-        - `mapId` が **階のID** の場合：その階の `parent_map_id`（=root.id）を特定して同様に返す。
-        - **常にグループ全体（root＋全階）** を返す。余計なクエリは不要。
+      summary: "マップ取得（単体Map）"
+      description: "単一の Map を返す。子メタ情報（children, childrenCount）を含む。"
       parameters:
         - in: path
           name: mapId
@@ -258,10 +265,14 @@ paths:
           schema: { type: string }
       responses:
         "200":
-          description: "取得成功（階スタック）"
+          description: "取得成功（単体Map）"
+          headers:
+            ETag:
+              description: "単体MapのETag"
+              schema: { type: string, example: 'W/"d4e5f6..."' }
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/FloorStackResponse" }
+              schema: { $ref: "#/components/schemas/MapResponse" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
 
@@ -281,6 +292,10 @@ paths:
       responses:
         "200":
           description: "更新成功（単体Map）"
+          headers:
+            ETag:
+              description: "更新後MapのETag"
+              schema: { type: string, example: 'W/"eeaa99..."' }
           content:
             application/json:
               schema: { $ref: "#/components/schemas/MapResponse" }
@@ -305,32 +320,59 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
 
-  # ───────────── Floors（追加／最上階削除） ─────────────
+  # ───────────── Floors（追加／最上階削除／スタック取得） ─────────────
   /maps/{mapId}/floors:
     post:
       tags: ["Maps"]
-      summary: "階追加（リクエストは /maps POST と同一：MapCreateRequest）"
+      summary: "階追加（空の階を1つ追加）"
+      description: |
+        パスの `{mapId}` を親（root）として、空の階を1つ作成する。  
+        リクエストボディは省略可（実装では未使用）。互換のため `MapCreateRequest` を受け付けてもよい。
+      parameters:
+        - in: path
+          name: mapId
+          required: true
+          schema: { type: string }
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema: { $ref: "#/components/schemas/MapCreateRequest" }
-            examples:
-              onlyParent:
-                summary: "ParentMapIDだけ渡す"
-                value: { parentMapId: "map_123" }
-              withName:
-                summary: "任意で階の表示名を指定"
-                value: { parentMapId: "map_123", name: "講義棟 4F" }
       responses:
         "201":
-          description: "作成成功（作成した階＋最新スタックを返す）"
+          description: "作成成功（作成された階の単体Map）"
+          headers:
+            ETag:
+              description: "作成された階（Map）のETag"
+              schema: { type: string, example: 'W/"112233..."' }
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/FloorCreateResult" }
+              schema: { $ref: "#/components/schemas/MapResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "404": { $ref: "#/components/responses/NotFound" }
-        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/ServerError" }
+
+    get:
+      tags: ["Maps"]
+      summary: "階スタック取得（1F..順）"
+      description: |
+        指定IDが root でも floor でも受け取り、所属 root の全フロアを 1F.. の順で返す。
+      parameters:
+        - in: path
+          name: mapId
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: "取得成功（階スタック）"
+          headers:
+            ETag:
+              description: "rootID と各階の最終更新から作るETag"
+              schema: { type: string, example: 'W/"778899..."' }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/FloorStackResponse" }
+        "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/ServerError" }
 
   /maps/{mapId}/floors/{floorIndex}:
@@ -339,7 +381,7 @@ paths:
       summary: "階削除（最上階のみ削除可）"
       description: |
         - `floorIndex` は **1..floor_count**。  
-        - **現在の `floor_count` と同じ値** のときのみ削除可（= 最上階のみ）。  
+        - **現在の `floor_count` と同じ（= 最上階）** ときのみ削除可。  
         - 削除後は root の `floor_count` を -1、0 なら `has_floors=false`。
       parameters:
         - in: path
@@ -352,11 +394,11 @@ paths:
           schema: { type: integer, minimum: 1 }
       responses:
         "204": { description: "削除成功（No Content）" }
+        "400": { $ref: "#/components/responses/BadRequest" }
         "404": { $ref: "#/components/responses/NotFound" }
-        "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/ServerError" }
 
-  # ───────────── Pins ─────────────
+  # ───────────── Pins（※元の仕様を保持） ─────────────
   /maps/{mapId}/pins:
     get:
       tags: ["Pins"]
@@ -617,7 +659,7 @@ components:
       type: object
       required:
         [ id, name, imageData, naturalWidth, naturalHeight,
-          parentMapId, hasFloors, floorCount, createdAt, modifiedAt ]
+          hasFloors, floorCount, createdAt, modifiedAt ]
       properties:
         id:
           type: string
@@ -646,13 +688,37 @@ components:
           example: null
         hasFloors:
           type: boolean
-          description: "root 側の集約フラグ"
+          description: "root 側の集約フラグ（floor では false が一般的）"
           example: true
         floorCount:
           type: integer
           minimum: 0
           description: "root 側の集約値"
           example: 3
+        childrenCount:
+          type: integer
+          minimum: 0
+          description: "子（直下の floor）件数（root のみ意味がある）"
+          example: 2
+        children:
+          type: array
+          description: "子（直下の floor）の軽量リスト"
+          items:
+            type: object
+            required: [id, name, hasFloors, floorCount]
+            properties:
+              id:
+                type: string
+                example: "floor_1"
+              name:
+                type: string
+                example: "1F"
+              hasFloors:
+                type: boolean
+                example: false
+              floorCount:
+                type: integer
+                example: 0
         createdAt:
           type: string
           format: date-time
@@ -690,6 +756,10 @@ components:
           type: integer
           minimum: 0
           example: 3500
+        parentMapId:
+          type: string
+          nullable: true
+          example: "root_123"
 
     FloorItem:
       type: object

--- a/services/nutfesmap-api/build/Dockerfile
+++ b/services/nutfesmap-api/build/Dockerfile
@@ -1,17 +1,23 @@
+# services/nutfesmap-api/build/Dockerfile
+
+# ---- Build stage ----
 FROM golang:1.24.5 AS builder
+WORKDIR /src
 
-WORKDIR /app
+# 依存キャッシュ
+COPY services/nutfesmap-api/go.mod services/nutfesmap-api/go.sum ./
+RUN go mod download
 
+# アプリ本体
 COPY services/nutfesmap-api/ .
 
-RUN go mod tidy
+# 静的リンクでビルド（CGO無効）
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -ldflags="-s -w" -o /out/server ./cmd/server
 
-RUN go build -o /app/server ./cmd/server
-
-FROM alpine:3.20
-
-COPY --from=builder /app/server /app/server
-
+# ---- Runtime stage ----
+FROM gcr.io/distroless/static-debian12
+WORKDIR /app
+COPY --from=builder /out/server /app/server
 EXPOSE 8080
-
 ENTRYPOINT ["/app/server"]

--- a/services/nutfesmap-api/internal/config/router.go
+++ b/services/nutfesmap-api/internal/config/router.go
@@ -96,9 +96,11 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	usersG := e.Group("/users", csrfMW)
 	usersG.POST("/register", userH.Register)
 
+	// /maps 公開
 	mapsG := e.Group("/maps", csrfMW)
 	mapsG.POST("", mapH.Create)
 	mapsG.GET("/index", mapH.Index)
+	mapsG.GET("/:mapId", mapH.Show)
 
 	// /users 認証必須
 	jwtCfg := echojwt.Config{

--- a/services/nutfesmap-api/internal/config/router.go
+++ b/services/nutfesmap-api/internal/config/router.go
@@ -101,6 +101,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	mapsG.POST("", mapH.Create)
 	mapsG.GET("/index", mapH.Index)
 	mapsG.GET("/:mapId", mapH.Show)
+	mapsG.PATCH("/:mapId", mapH.Update)
 
 	// /users 認証必須
 	jwtCfg := echojwt.Config{

--- a/services/nutfesmap-api/internal/config/router.go
+++ b/services/nutfesmap-api/internal/config/router.go
@@ -102,6 +102,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	mapsG.GET("/index", mapH.Index)
 	mapsG.GET("/:mapId", mapH.Show)
 	mapsG.PATCH("/:mapId", mapH.Update)
+	mapsG.DELETE("/:mapId", mapH.Delete)
 
 	// /users 認証必須
 	jwtCfg := echojwt.Config{

--- a/services/nutfesmap-api/internal/config/router.go
+++ b/services/nutfesmap-api/internal/config/router.go
@@ -98,6 +98,13 @@ func SetupRouter(cfg *Config) *echo.Echo {
 
 	// /maps 公開
 	mapsG := e.Group("/maps", csrfMW)
+
+	// まず floors 系を先に
+	mapsG.POST("/:mapId/floors", mapH.CreateFloor)                  // 追加
+	mapsG.DELETE("/:mapId/floors/:floorIndex", mapH.DeleteTopFloor) // 最上階削除
+	mapsG.GET("/:mapId/floors", mapH.ListFloors)                    // 一覧（1F..）
+
+	// 次に汎用
 	mapsG.POST("", mapH.Create)
 	mapsG.GET("/index", mapH.Index)
 	mapsG.GET("/:mapId", mapH.Show)
@@ -119,5 +126,10 @@ func SetupRouter(cfg *Config) *echo.Echo {
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })
+
+	for _, r := range e.Routes() {
+		e.Logger.Infof("route: %-6s %s -> %s", r.Method, r.Path, r.Name)
+	}
+
 	return e
 }

--- a/services/nutfesmap-api/internal/handlers/map.go
+++ b/services/nutfesmap-api/internal/handlers/map.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"net/http"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,38 +17,16 @@ import (
 	"nutfesmap/internal/repository"
 )
 
-// ---- Request / Response DTO ----
-
-type MapChildRefDTO struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	HasFloors  bool   `json:"hasFloors"`
-	FloorCount int    `json:"floorCount"`
-}
-
-type MapResponse struct {
-	ID            string           `json:"id"`
-	Name          string           `json:"name"`
-	ImageData     string           `json:"imageData"`
-	NaturalWidth  int              `json:"naturalWidth"`
-	NaturalHeight int              `json:"naturalHeight"`
-	ParentMapID   *string          `json:"parentMapId,omitempty"`
-	HasFloors     bool             `json:"hasFloors"`
-	FloorCount    int              `json:"floorCount"`
-	ChildrenCount int              `json:"childrenCount"`
-	Children      []MapChildRefDTO `json:"children"`
-	CreatedAt     time.Time        `json:"createdAt"`
-	ModifiedAt    time.Time        `json:"modifiedAt"`
-}
+// ---- Request DTO ----
 
 // POST /maps（空マップ作成）リクエスト
 type MapCreateRequest struct {
 	ParentMapID *string `json:"parentMapId"`
 }
 
-// レスポンス全体ラッパ
+// レスポンス全体ラッパ（/maps/index）
 type MapsIndexResponse struct {
-	Items []MapResponse `json:"items"`
+	Items []repository.MapResponse `json:"items"`
 }
 
 type MapHandler struct {
@@ -69,78 +49,43 @@ func (h *MapHandler) Create(c echo.Context) error {
 	ctx := c.Request().Context()
 
 	// 空マップを作成（name/image/natural_* は未設定、親のみ任意）
-	if err := h.Repo.CreateEmpty(ctx, newID, req.ParentMapID); err != nil {
+	if err := h.Repo.CreateEmptyMapTx(ctx, newID, req.ParentMapID); err != nil {
 		// DB起因の失敗はそのまま Echo が 500 にマップ
 		return err
 	}
 
-	// 作成直後の状態を再取得
-	agg, err := h.Repo.FindAggregate(ctx, newID)
+	// 作成直後の状態を取得（常に repository.MapResponse を返す）
+	res, err := h.Repo.FindMapResponseByID(ctx, newID)
 	if err != nil {
 		return err
 	}
-
-	// 正常系: Aggregate からレスポンス構築
-	if agg != nil && agg.Base != nil {
-		children := make([]MapChildRefDTO, 0, len(agg.Children))
-		for _, ch := range agg.Children {
-			children = append(children, MapChildRefDTO{
-				ID:         ch.ID,
-				Name:       ch.Name,
-				HasFloors:  ch.HasFloors,
-				FloorCount: ch.FloorCount,
-			})
+	if res == nil {
+		// まれに直後の再読込に失敗した場合のフォールバック
+		now := time.Now().UTC()
+		res = &repository.MapResponse{
+			ID:            newID,
+			Name:          "",
+			ImageData:     "",
+			NaturalWidth:  0,
+			NaturalHeight: 0,
+			ParentMapID:   req.ParentMapID,
+			HasFloors:     false,
+			FloorCount:    0,
+			ChildrenCount: 0,
+			Children:      []repository.MapChildRefDTO{},
+			CreatedAt:     now,
+			ModifiedAt:    now,
 		}
-		res := MapResponse{
-			ID:            agg.Base.ID,
-			Name:          agg.Base.Name,
-			ImageData:     agg.Base.ImageData, // LONGTEXT(base64) をそのまま返す
-			NaturalWidth:  agg.Base.NaturalWidth,
-			NaturalHeight: agg.Base.NaturalHeight,
-			ParentMapID:   agg.Base.ParentMapID,
-			HasFloors:     agg.Base.HasFloors,
-			FloorCount:    agg.Base.FloorCount,
-			ChildrenCount: agg.ChildrenCount,
-			Children:      children,
-			CreatedAt:     agg.Base.CreatedAt,
-			ModifiedAt:    agg.Base.ModifiedAt,
-		}
-
-		// ETag: ID + ModifiedAt
-		hash := sha256.New()
-		hash.Write([]byte(res.ID))
-		hash.Write([]byte(res.ModifiedAt.UTC().Format(time.RFC3339Nano)))
-		etag := `W/"` + hex.EncodeToString(hash.Sum(nil)) + `"`
-		c.Response().Header().Set("ETag", etag)
-
-		return c.JSON(http.StatusCreated, res)
 	}
 
-	// まれに直後の再読込に失敗した場合のフォールバック
-	now := time.Now().UTC()
-	fallback := MapResponse{
-		ID:            newID,
-		Name:          "",
-		ImageData:     "",
-		NaturalWidth:  0,
-		NaturalHeight: 0,
-		ParentMapID:   req.ParentMapID,
-		HasFloors:     false,
-		FloorCount:    0,
-		ChildrenCount: 0,
-		Children:      []MapChildRefDTO{},
-		CreatedAt:     now,
-		ModifiedAt:    now,
-	}
-
-	// フォールバックでも ETag を必ず付与
+	// ETag: ID + ModifiedAt
 	hash := sha256.New()
-	hash.Write([]byte(fallback.ID))
-	hash.Write([]byte(fallback.ModifiedAt.UTC().Format(time.RFC3339Nano)))
+	hash.Write([]byte(res.ID))
+	hash.Write([]byte(res.ModifiedAt.UTC().Format(time.RFC3339Nano)))
 	etag := `W/"` + hex.EncodeToString(hash.Sum(nil)) + `"`
 	c.Response().Header().Set("ETag", etag)
 
-	return c.JSON(http.StatusCreated, fallback)
+	return c.JSON(http.StatusCreated, res)
 }
 
 // GET /maps/index
@@ -152,18 +97,18 @@ func (h *MapHandler) Index(c echo.Context) error {
 		return err
 	}
 
-	items := make([]MapResponse, 0, len(ags))
+	items := make([]repository.MapResponse, 0, len(ags))
 	hash := sha256.New()
 
 	for _, ag := range ags {
-		// 念のため子を Name 昇順に
+		// 子を Name 昇順で安定化
 		sort.Slice(ag.Children, func(i, j int) bool {
 			return ag.Children[i].Name < ag.Children[j].Name
 		})
 
-		children := make([]MapChildRefDTO, 0, len(ag.Children))
+		children := make([]repository.MapChildRefDTO, 0, len(ag.Children))
 		for _, ch := range ag.Children {
-			children = append(children, MapChildRefDTO{
+			children = append(children, repository.MapChildRefDTO{
 				ID:         ch.ID,
 				Name:       ch.Name,
 				HasFloors:  ch.HasFloors,
@@ -172,7 +117,7 @@ func (h *MapHandler) Index(c echo.Context) error {
 		}
 
 		base := ag.Base
-		items = append(items, MapResponse{
+		items = append(items, repository.MapResponse{
 			ID:            base.ID,
 			Name:          base.Name,
 			ImageData:     base.ImageData, // LONGTEXT(base64)
@@ -290,4 +235,118 @@ func (h *MapHandler) Delete(c echo.Context) error {
 
 	// 本体・子マップ・ピンを再帰的に削除済み
 	return c.NoContent(http.StatusNoContent)
+}
+
+// POST /maps/:mapId/floors
+// 指定 root の直下に空の Floor を1件追加し、作成された Floor の MapResponse を返します。
+func (h *MapHandler) CreateFloor(c echo.Context) error {
+	mapID := c.Param("mapId")
+	if mapID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
+	}
+
+	newID := uuid.NewString()
+	ctx := c.Request().Context()
+
+	// 親(root)存在チェック＋作成（内部で FOR UPDATE / 集約更新あり）
+	if err := h.Repo.CreateEmptyMapTx(ctx, newID, &mapID); err != nil {
+		// 親なし → 404 に寄せる（Repository は "parent root not found" のエラー文字列）
+		if strings.Contains(err.Error(), "parent root not found") {
+			return echo.NewHTTPError(http.StatusNotFound, "parent root not found")
+		}
+		return err // その他は 500
+	}
+
+	// 作成した Floor を返却
+	res, err := h.Repo.FindMapResponseByID(ctx, newID)
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		// 直後の再取得に失敗した場合のフォールバック
+		now := time.Now().UTC()
+		res = &repository.MapResponse{
+			ID:            newID,
+			Name:          "",
+			ImageData:     "",
+			NaturalWidth:  0,
+			NaturalHeight: 0,
+			ParentMapID:   &mapID,
+			HasFloors:     false,
+			FloorCount:    0,
+			ChildrenCount: 0,
+			Children:      []repository.MapChildRefDTO{},
+			CreatedAt:     now,
+			ModifiedAt:    now,
+		}
+	}
+
+	// ETag（ID + ModifiedAt）
+	hsh := sha256.New()
+	hsh.Write([]byte(res.ID))
+	hsh.Write([]byte(res.ModifiedAt.UTC().Format(time.RFC3339Nano)))
+	c.Response().Header().Set("ETag", `W/"`+hex.EncodeToString(hsh.Sum(nil))+`"`)
+
+	return c.JSON(http.StatusCreated, res)
+}
+
+// DELETE /maps/:mapId/floors/:floorIndex
+// 最上階のみ削除可能。floorIndex は 1..floor_count で、現状の floor_count と一致したときのみ削除。
+func (h *MapHandler) DeleteTopFloor(c echo.Context) error {
+	mapID := c.Param("mapId")
+	if mapID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
+	}
+	idxStr := c.Param("floorIndex")
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "floorIndex must be an integer")
+	}
+
+	ctx := c.Request().Context()
+	if err := h.Repo.DeleteTopFloorByIndex(ctx, mapID, idx); err != nil {
+		// NOT FOUND 相当
+		if errors.Is(err, sql.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "map not found")
+		}
+		// ドメイン検証エラー系は 400 に寄せる
+		if strings.Contains(err.Error(), "floorIndex must be") ||
+			strings.Contains(err.Error(), "no floors to delete") ||
+			strings.Contains(err.Error(), "only top floor") {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		// その他は 500
+		return err
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// GET /maps/:mapId/floors
+// 指定IDが root でも floor でも受け取り、所属 root の全フロアを 1F.. の順で返します。
+func (h *MapHandler) ListFloors(c echo.Context) error {
+	mapID := c.Param("mapId")
+	if mapID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
+	}
+
+	ctx := c.Request().Context()
+	fs, err := h.Repo.FindFloorStackByAnyID(ctx, mapID)
+	if err != nil {
+		return err
+	}
+	if fs == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "map not found")
+	}
+
+	// ETag（rootID + 各階 ModifiedAt）
+	hsh := sha256.New()
+	hsh.Write([]byte(fs.RootMapID))
+	for _, it := range fs.Items {
+		hsh.Write([]byte(it.Map.ModifiedAt.UTC().Format(time.RFC3339Nano)))
+	}
+	c.Response().Header().Set("ETag", `W/"`+hex.EncodeToString(hsh.Sum(nil))+`"`)
+
+	// repository.FloorStackResponse をそのまま返却
+	return c.JSON(http.StatusOK, fs)
 }

--- a/services/nutfesmap-api/internal/handlers/map.go
+++ b/services/nutfesmap-api/internal/handlers/map.go
@@ -200,3 +200,34 @@ func (h *MapHandler) Index(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, MapsIndexResponse{Items: items})
 }
+
+// GET /maps/:mapId （地図メタ取得）
+func (h *MapHandler) Show(c echo.Context) error {
+	mapID := strings.TrimSpace(c.Param("mapId"))
+	if mapID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
+	}
+
+	ctx := c.Request().Context()
+	res, err := h.Repo.FindMapResponseByID(ctx, mapID)
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "map not found")
+	}
+
+	// 子は名前昇順で安定化
+	sort.Slice(res.Children, func(i, j int) bool {
+		return res.Children[i].Name < res.Children[j].Name
+	})
+
+	// 単体ETag: ID + ModifiedAt
+	hash := sha256.New()
+	hash.Write([]byte(res.ID))
+	hash.Write([]byte(res.ModifiedAt.UTC().Format(time.RFC3339Nano)))
+	etag := `W/"` + hex.EncodeToString(hash.Sum(nil)) + `"`
+	c.Response().Header().Set("ETag", etag)
+
+	return c.JSON(http.StatusOK, res)
+}

--- a/services/nutfesmap-api/internal/handlers/map.go
+++ b/services/nutfesmap-api/internal/handlers/map.go
@@ -48,19 +48,20 @@ func (h *MapHandler) Create(c echo.Context) error {
 	newID := uuid.NewString()
 	ctx := c.Request().Context()
 
-	// 空マップを作成（name/image/natural_* は未設定、親のみ任意）
-	if err := h.Repo.CreateEmptyMapTx(ctx, newID, req.ParentMapID); err != nil {
-		// DB起因の失敗はそのまま Echo が 500 にマップ
+	// 親なし=ルート作成／親あり=フロア追加（親の has_floors/floor_count も更新）
+	if err := h.Repo.CreateByRequest(ctx, newID, &repository.MapCreateRequest{
+		ParentMapID: req.ParentMapID,
+	}); err != nil {
 		return err
 	}
 
-	// 作成直後の状態を取得（常に repository.MapResponse を返す）
+	// 作成直後の状態を取得
 	res, err := h.Repo.FindMapResponseByID(ctx, newID)
 	if err != nil {
 		return err
 	}
 	if res == nil {
-		// まれに直後の再読込に失敗した場合のフォールバック
+		// 直後の再読込に失敗した場合のフォールバック
 		now := time.Now().UTC()
 		res = &repository.MapResponse{
 			ID:            newID,
@@ -237,8 +238,8 @@ func (h *MapHandler) Delete(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-// POST /maps/:mapId/floors
-// 指定 root の直下に空の Floor を1件追加し、作成された Floor の MapResponse を返します。
+// フロア専用作成: {mapId} をフロアスタックのルート（通常はエリア）として、空のフロアを1件追加。
+// 親エリアの has_floors=true / floor_count++ を更新します。
 func (h *MapHandler) CreateFloor(c echo.Context) error {
 	mapID := c.Param("mapId")
 	if mapID == "" {
@@ -248,16 +249,17 @@ func (h *MapHandler) CreateFloor(c echo.Context) error {
 	newID := uuid.NewString()
 	ctx := c.Request().Context()
 
-	// 親(root)存在チェック＋作成（内部で FOR UPDATE / 集約更新あり）
-	if err := h.Repo.CreateEmptyMapTx(ctx, newID, &mapID); err != nil {
-		// 親なし → 404 に寄せる（Repository は "parent root not found" のエラー文字列）
-		if strings.Contains(err.Error(), "parent root not found") {
-			return echo.NewHTTPError(http.StatusNotFound, "parent root not found")
+	// 変更点: Repo.CreateEmptyFloorTx を使用（親の集約値を更新）
+	if err := h.Repo.CreateEmptyFloorTx(ctx, newID, mapID); err != nil {
+		// 親（=フロアルート=エリア）なし → 404
+		// Repository 側は "floor root not found: <id>" を返す
+		if strings.Contains(err.Error(), "floor root not found") {
+			return echo.NewHTTPError(http.StatusNotFound, "floor root not found")
 		}
 		return err // その他は 500
 	}
 
-	// 作成した Floor を返却
+	// 作成したフロアを返却
 	res, err := h.Repo.FindMapResponseByID(ctx, newID)
 	if err != nil {
 		return err
@@ -323,7 +325,10 @@ func (h *MapHandler) DeleteTopFloor(c echo.Context) error {
 }
 
 // GET /maps/:mapId/floors
-// 指定IDが root でも floor でも受け取り、所属 root の全フロアを 1F.. の順で返します。
+// フロアスタック取得:
+// - {mapId} がエリア    → その直下のフロアを 1F.. 順で返す
+// - {mapId} がフロア    → 親エリア直下の全フロアを返す
+// - {mapId} が Index    → 空のスタック（floorCount=0, items=[]）を返す
 func (h *MapHandler) ListFloors(c echo.Context) error {
 	mapID := c.Param("mapId")
 	if mapID == "" {
@@ -347,6 +352,5 @@ func (h *MapHandler) ListFloors(c echo.Context) error {
 	}
 	c.Response().Header().Set("ETag", `W/"`+hex.EncodeToString(hsh.Sum(nil))+`"`)
 
-	// repository.FloorStackResponse をそのまま返却
 	return c.JSON(http.StatusOK, fs)
 }

--- a/services/nutfesmap-api/internal/handlers/map.go
+++ b/services/nutfesmap-api/internal/handlers/map.go
@@ -274,3 +274,25 @@ func (h *MapHandler) Update(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, updated)
 }
+
+// DELETE /maps/:mapId
+func (h *MapHandler) Delete(c echo.Context) error {
+	mapID := strings.TrimSpace(c.Param("mapId"))
+	if mapID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
+	}
+
+	ctx := c.Request().Context()
+	_, _, err := h.Repo.DeleteCascade(ctx, mapID)
+	if err != nil {
+		// 対象なし
+		if err.Error() == "sql: no rows in result set" {
+			return echo.NewHTTPError(http.StatusNotFound, "map not found")
+		}
+		// それ以外は内部エラーとして扱う（Echo 側で 500 にマップ）
+		return err
+	}
+
+	// 本体・子マップ・ピンを再帰的に削除済み
+	return c.NoContent(http.StatusNoContent)
+}

--- a/services/nutfesmap-api/internal/handlers/map.go
+++ b/services/nutfesmap-api/internal/handlers/map.go
@@ -2,30 +2,21 @@ package handlers
 
 import (
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
-	"nutfesmap/internal/model"
 	"nutfesmap/internal/repository"
 )
 
-type MapCreateRequest struct {
-	Name          string  `json:"name"          validate:"required,min=1"`
-	ImageData     string  `json:"imageData"     validate:"required"` // base64
-	NaturalWidth  int     `json:"naturalWidth"  validate:"required,min=1"`
-	NaturalHeight int     `json:"naturalHeight" validate:"required,min=1"`
-	ParentMapID   *string `json:"parentMapId"`
-	HasFloors     bool    `json:"hasFloors"`
-	FloorCount    int     `json:"floorCount"    validate:"min=0"`
-}
+// ---- Request / Response DTO ----
 
-// Response DTO（外部契約）
 type MapChildRefDTO struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
@@ -48,6 +39,11 @@ type MapResponse struct {
 	ModifiedAt    time.Time        `json:"modifiedAt"`
 }
 
+// POST /maps（空マップ作成）リクエスト
+type MapCreateRequest struct {
+	ParentMapID *string `json:"parentMapId"`
+}
+
 // レスポンス全体ラッパ
 type MapsIndexResponse struct {
 	Items []MapResponse `json:"items"`
@@ -62,46 +58,29 @@ func NewMapHandler(r *repository.MapRepository) *MapHandler {
 }
 
 // POST /maps
+// 空のマップのみ作成。name / imageData / natural* / floors は受け付けない。
 func (h *MapHandler) Create(c echo.Context) error {
 	var req MapCreateRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid payload")
 	}
-	if err := c.Validate(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-
-	// 追加の軽い検証（ドメイン制約）
-	if strings.TrimSpace(req.ImageData) == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "imageData is required")
-	}
-	if req.HasFloors && req.FloorCount < 1 {
-		return echo.NewHTTPError(http.StatusBadRequest, "floorCount must be >= 1 when hasFloors=true")
-	}
 
 	newID := uuid.NewString()
-	m := &model.Map{
-		ID:            newID,
-		Name:          req.Name,
-		ImageData:     req.ImageData,
-		NaturalWidth:  req.NaturalWidth,
-		NaturalHeight: req.NaturalHeight,
-		ParentMapID:   req.ParentMapID,
-		HasFloors:     req.HasFloors,
-		FloorCount:    req.FloorCount,
-	}
-
 	ctx := c.Request().Context()
-	if err := h.Repo.Insert(ctx, m); err != nil {
+
+	// 空マップを作成（name/image/natural_* は未設定、親のみ任意）
+	if err := h.Repo.CreateEmpty(ctx, newID, req.ParentMapID); err != nil {
+		// DB起因の失敗はそのまま Echo が 500 にマップ
 		return err
 	}
 
+	// 作成直後の状態を再取得
 	agg, err := h.Repo.FindAggregate(ctx, newID)
 	if err != nil {
 		return err
 	}
 
-	// 正常系：Aggregate からレスポンスDTOを組み立て
+	// 正常系: Aggregate からレスポンス構築
 	if agg != nil && agg.Base != nil {
 		children := make([]MapChildRefDTO, 0, len(agg.Children))
 		for _, ch := range agg.Children {
@@ -115,7 +94,7 @@ func (h *MapHandler) Create(c echo.Context) error {
 		res := MapResponse{
 			ID:            agg.Base.ID,
 			Name:          agg.Base.Name,
-			ImageData:     agg.Base.ImageData,
+			ImageData:     agg.Base.ImageData, // LONGTEXT(base64) をそのまま返す
 			NaturalWidth:  agg.Base.NaturalWidth,
 			NaturalHeight: agg.Base.NaturalHeight,
 			ParentMapID:   agg.Base.ParentMapID,
@@ -126,22 +105,41 @@ func (h *MapHandler) Create(c echo.Context) error {
 			CreatedAt:     agg.Base.CreatedAt,
 			ModifiedAt:    agg.Base.ModifiedAt,
 		}
+
+		// ETag: ID + ModifiedAt
+		hash := sha256.New()
+		hash.Write([]byte(res.ID))
+		hash.Write([]byte(res.ModifiedAt.UTC().Format(time.RFC3339Nano)))
+		etag := `W/"` + hex.EncodeToString(hash.Sum(nil)) + `"`
+		c.Response().Header().Set("ETag", etag)
+
 		return c.JSON(http.StatusCreated, res)
 	}
 
 	// まれに直後の再読込に失敗した場合のフォールバック
+	now := time.Now().UTC()
 	fallback := MapResponse{
-		ID:            m.ID,
-		Name:          m.Name,
-		ImageData:     m.ImageData,
-		NaturalWidth:  m.NaturalWidth,
-		NaturalHeight: m.NaturalHeight,
-		ParentMapID:   m.ParentMapID,
-		HasFloors:     m.HasFloors,
-		FloorCount:    m.FloorCount,
+		ID:            newID,
+		Name:          "",
+		ImageData:     "",
+		NaturalWidth:  0,
+		NaturalHeight: 0,
+		ParentMapID:   req.ParentMapID,
+		HasFloors:     false,
+		FloorCount:    0,
 		ChildrenCount: 0,
 		Children:      []MapChildRefDTO{},
+		CreatedAt:     now,
+		ModifiedAt:    now,
 	}
+
+	// フォールバックでも ETag を必ず付与
+	hash := sha256.New()
+	hash.Write([]byte(fallback.ID))
+	hash.Write([]byte(fallback.ModifiedAt.UTC().Format(time.RFC3339Nano)))
+	etag := `W/"` + hex.EncodeToString(hash.Sum(nil)) + `"`
+	c.Response().Header().Set("ETag", etag)
+
 	return c.JSON(http.StatusCreated, fallback)
 }
 
@@ -154,7 +152,6 @@ func (h *MapHandler) Index(c echo.Context) error {
 		return err
 	}
 
-	// 並びの安定化（子は名前昇順、親は作成日降順はリポジトリ側SQLで担保）
 	items := make([]MapResponse, 0, len(ags))
 	hash := sha256.New()
 
@@ -178,7 +175,7 @@ func (h *MapHandler) Index(c echo.Context) error {
 		items = append(items, MapResponse{
 			ID:            base.ID,
 			Name:          base.Name,
-			ImageData:     base.ImageData,
+			ImageData:     base.ImageData, // LONGTEXT(base64)
 			NaturalWidth:  base.NaturalWidth,
 			NaturalHeight: base.NaturalHeight,
 			ParentMapID:   base.ParentMapID,
@@ -232,35 +229,33 @@ func (h *MapHandler) Show(c echo.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
+// PATCH /maps/:mapId
 func (h *MapHandler) Update(c echo.Context) error {
 	mapID := c.Param("mapId")
 	if mapID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
 	}
 
-	// 部分更新の受け口（すべて任意項目）
+	// 受け取り: name / imageData / naturalWidth / naturalHeight / parentMapId のみ
 	var req repository.MapUpdateRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid JSON body")
 	}
-	// Create と違い、バリデーションは基本的にリポジトリ側で実施
 
 	ctx := c.Request().Context()
 	updated, err := h.Repo.UpdatePartial(ctx, mapID, &req)
 	if err != nil {
-		// NotFound（対象が存在しない or 競合で削除された）
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return echo.NewHTTPError(http.StatusNotFound, "map not found")
 		}
-		// リポジトリでのドメイン検証エラー（fmt.Errorf 等）は400に寄せる
+		// ドメイン検証エラーなどは 400 に寄せる（UpdatePartial は検証時に error を返す）
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if updated == nil {
-		// 念のため
 		return echo.NewHTTPError(http.StatusNotFound, "map not found")
 	}
 
-	// 子は名前昇順で安定化（FindMapResponseByID と同様の整形）
+	// 子は名前昇順で安定化
 	sort.Slice(updated.Children, func(i, j int) bool {
 		return updated.Children[i].Name < updated.Children[j].Name
 	})
@@ -286,7 +281,7 @@ func (h *MapHandler) Delete(c echo.Context) error {
 	_, _, err := h.Repo.DeleteCascade(ctx, mapID)
 	if err != nil {
 		// 対象なし
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return echo.NewHTTPError(http.StatusNotFound, "map not found")
 		}
 		// それ以外は内部エラーとして扱う（Echo 側で 500 にマップ）

--- a/services/nutfesmap-api/internal/handlers/map.go
+++ b/services/nutfesmap-api/internal/handlers/map.go
@@ -79,7 +79,7 @@ func (h *MapHandler) Create(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "floorCount must be >= 1 when hasFloors=true")
 	}
 
-	newID := "map_" + uuid.NewString()
+	newID := uuid.NewString()
 	m := &model.Map{
 		ID:            newID,
 		Name:          req.Name,
@@ -203,7 +203,7 @@ func (h *MapHandler) Index(c echo.Context) error {
 
 // GET /maps/:mapId （地図メタ取得）
 func (h *MapHandler) Show(c echo.Context) error {
-	mapID := strings.TrimSpace(c.Param("mapId"))
+	mapID := c.Param("mapId")
 	if mapID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
 	}
@@ -233,7 +233,7 @@ func (h *MapHandler) Show(c echo.Context) error {
 }
 
 func (h *MapHandler) Update(c echo.Context) error {
-	mapID := strings.TrimSpace(c.Param("mapId"))
+	mapID := c.Param("mapId")
 	if mapID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
 	}
@@ -277,7 +277,7 @@ func (h *MapHandler) Update(c echo.Context) error {
 
 // DELETE /maps/:mapId
 func (h *MapHandler) Delete(c echo.Context) error {
-	mapID := strings.TrimSpace(c.Param("mapId"))
+	mapID := c.Param("mapId")
 	if mapID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
 	}

--- a/services/nutfesmap-api/internal/handlers/map.go
+++ b/services/nutfesmap-api/internal/handlers/map.go
@@ -231,3 +231,46 @@ func (h *MapHandler) Show(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, res)
 }
+
+func (h *MapHandler) Update(c echo.Context) error {
+	mapID := strings.TrimSpace(c.Param("mapId"))
+	if mapID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "mapId is required")
+	}
+
+	// 部分更新の受け口（すべて任意項目）
+	var req repository.MapUpdateRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid JSON body")
+	}
+	// Create と違い、バリデーションは基本的にリポジトリ側で実施
+
+	ctx := c.Request().Context()
+	updated, err := h.Repo.UpdatePartial(ctx, mapID, &req)
+	if err != nil {
+		// NotFound（対象が存在しない or 競合で削除された）
+		if err.Error() == "sql: no rows in result set" {
+			return echo.NewHTTPError(http.StatusNotFound, "map not found")
+		}
+		// リポジトリでのドメイン検証エラー（fmt.Errorf 等）は400に寄せる
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if updated == nil {
+		// 念のため
+		return echo.NewHTTPError(http.StatusNotFound, "map not found")
+	}
+
+	// 子は名前昇順で安定化（FindMapResponseByID と同様の整形）
+	sort.Slice(updated.Children, func(i, j int) bool {
+		return updated.Children[i].Name < updated.Children[j].Name
+	})
+
+	// ETag: ID + ModifiedAt
+	hash := sha256.New()
+	hash.Write([]byte(updated.ID))
+	hash.Write([]byte(updated.ModifiedAt.UTC().Format(time.RFC3339Nano)))
+	etag := `W/"` + hex.EncodeToString(hash.Sum(nil)) + `"`
+	c.Response().Header().Set("ETag", etag)
+
+	return c.JSON(http.StatusOK, updated)
+}

--- a/services/nutfesmap-api/internal/repository/map.go
+++ b/services/nutfesmap-api/internal/repository/map.go
@@ -14,7 +14,15 @@ import (
 
 type MapRepository struct{ DB *sql.DB }
 
+func NewMapRepository(db *sql.DB) *MapRepository { return &MapRepository{DB: db} }
+
+//
+// ====== リクエスト/レスポンス DTO ======
+//
+
 type MapCreateRequest struct {
+	// Swagger準拠: parentMapId のみ
+	// null なら root 作成、rootId を指定すると空の floor を1つ作成
 	ParentMapID *string `json:"parentMapId"`
 }
 
@@ -48,45 +56,83 @@ type MapResponse struct {
 	ModifiedAt    time.Time        `json:"modifiedAt"`
 }
 
-func NewMapRepository(db *sql.DB) *MapRepository { return &MapRepository{DB: db} }
+// FloorStack用DTO（Swagger準拠）
+type FloorItemDTO struct {
+	FloorIndex int         `json:"floorIndex"`
+	Map        MapResponse `json:"map"`
+}
 
-// 作成（空マップ）: name=""、image_data=NULL、natural_*=0
-func (r *MapRepository) CreateEmpty(ctx context.Context, id string, parentID *string) error {
+type FloorStackResponse struct {
+	RootMapID  string         `json:"rootMapId"`
+	RootName   string         `json:"rootName"`
+	FloorCount int            `json:"floorCount"`
+	Items      []FloorItemDTO `json:"items"`
+}
+
+//
+// ====== 作成（root/floor） ======
+//
+
+// CreateEmptyMapTx: parentID=nil なら root を作成、非nilなら floor を作成し root の集約値を更新。
+// 外からは CreateByRequest を使う想定。
+func (r *MapRepository) CreateEmptyMapTx(ctx context.Context, id string, parentID *string) error {
+	tx, err := r.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+
 	now := time.Now().UTC()
 
+	// floor の場合は root の存在チェック（FOR UPDATE）
+	if parentID != nil {
+		var cnt int
+		if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM maps WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL FOR UPDATE", *parentID).Scan(&cnt); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if cnt == 0 {
+			_ = tx.Rollback()
+			return fmt.Errorf("parent root not found: %s", *parentID)
+		}
+	}
+
+	// INSERT（has_floors=false, floor_count=0 を明示）
 	var parent any
 	if parentID == nil {
 		parent = nil
 	} else {
 		parent = *parentID
 	}
-
-	_, err := r.DB.ExecContext(ctx, `
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`, id, "", nil, 0, 0, parent, now, now)
-	return err
-}
-
-// 既存互換（最小挿入）
-func (r *MapRepository) Insert(ctx context.Context, m *model.Map) error {
-	now := time.Now().UTC()
-
-	var parent any
-	if m.ParentMapID == nil {
-		parent = nil
-	} else {
-		parent = *m.ParentMapID
+	if _, err := tx.ExecContext(ctx, "INSERT INTO maps (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at) VALUES (?,?,?,?,?,?,?,?,?,?)", id, "", nil, 0, 0, parent, false, 0, now, now); err != nil {
+		_ = tx.Rollback()
+		return err
 	}
 
-	_, err := r.DB.ExecContext(ctx, `
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`, m.ID, "", nil, 0, 0, parent, now, now)
-	return err
+	// floor 追加時は親 root を更新
+	if parentID != nil {
+		if _, err := tx.ExecContext(ctx, "UPDATE maps SET has_floors = TRUE, floor_count = floor_count + 1, modified_at = ? WHERE id = ? AND deleted_at IS NULL", now, *parentID); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
 }
+
+// 仕様に合わせた入口: /maps POST および /maps/{id}/floors POST の実体
+func (r *MapRepository) CreateByRequest(ctx context.Context, newID string, req *MapCreateRequest) error {
+	return r.CreateEmptyMapTx(ctx, newID, req.ParentMapID)
+}
+
+//
+// ====== 取得（単体・index・階スタック） ======
+//
 
 type MapAggregate struct {
 	Base          *model.Map
@@ -95,23 +141,7 @@ type MapAggregate struct {
 }
 
 func (r *MapRepository) FindAggregate(ctx context.Context, id string) (*MapAggregate, error) {
-	row := r.DB.QueryRowContext(ctx, `
-		SELECT
-		  id,
-		  COALESCE(name, ''),
-		  COALESCE(image_data, ''),
-		  COALESCE(natural_width, 0),
-		  COALESCE(natural_height, 0),
-		  parent_map_id,
-		  has_floors,
-		  floor_count,
-		  created_at,
-		  modified_at,
-		  deleted_at
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`, id)
+	row := r.DB.QueryRowContext(ctx, "SELECT id, COALESCE(name, ''), COALESCE(image_data, ''), COALESCE(natural_width, 0), COALESCE(natural_height, 0), parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at FROM maps WHERE id = ? AND deleted_at IS NULL LIMIT 1", id)
 
 	var base model.Map
 	var imgStr string
@@ -119,17 +149,9 @@ func (r *MapRepository) FindAggregate(ctx context.Context, id string) (*MapAggre
 	var deletedAtN sql.NullTime
 
 	if err := row.Scan(
-		&base.ID,
-		&base.Name,
-		&imgStr,
-		&base.NaturalWidth,
-		&base.NaturalHeight,
-		&parentNS,
-		&base.HasFloors,
-		&base.FloorCount,
-		&base.CreatedAt,
-		&base.ModifiedAt,
-		&deletedAtN,
+		&base.ID, &base.Name, &imgStr, &base.NaturalWidth, &base.NaturalHeight,
+		&parentNS, &base.HasFloors, &base.FloorCount,
+		&base.CreatedAt, &base.ModifiedAt, &deletedAtN,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -144,24 +166,16 @@ func (r *MapRepository) FindAggregate(ctx context.Context, id string) (*MapAggre
 		t := deletedAtN.Time
 		base.DeletedAt = &t
 	}
-	// LONGTEXTはそのまま返す
 	base.ImageData = imgStr
 
 	// 子件数
 	var cnt int
-	if err := r.DB.QueryRowContext(ctx, `
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`, base.ID).Scan(&cnt); err != nil {
+	if err := r.DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL", base.ID).Scan(&cnt); err != nil {
 		return nil, err
 	}
 
 	// 子一覧
-	rows, err := r.DB.QueryContext(ctx, `
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`, base.ID)
+	rows, err := r.DB.QueryContext(ctx, "SELECT id, COALESCE(name, ''), has_floors, floor_count FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL ORDER BY name", base.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -179,33 +193,12 @@ func (r *MapRepository) FindAggregate(ctx context.Context, id string) (*MapAggre
 		return nil, err
 	}
 
-	return &MapAggregate{
-		Base:          &base,
-		ChildrenCount: cnt,
-		Children:      children,
-	}, nil
+	return &MapAggregate{Base: &base, ChildrenCount: cnt, Children: children}, nil
 }
 
-// 親（root）一覧と子の簡易情報
+// Index（root一覧＋各rootの軽量な子情報）
 func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregate, error) {
-	parentRows, err := r.DB.QueryContext(ctx, `
-		SELECT
-		  id,
-		  COALESCE(name, ''),
-		  COALESCE(image_data, ''),
-		  COALESCE(natural_width, 0),
-		  COALESCE(natural_height, 0),
-		  parent_map_id,
-		  has_floors,
-		  floor_count,
-		  created_at,
-		  modified_at,
-		  deleted_at
-		FROM maps
-		WHERE parent_map_id IS NULL
-		  AND deleted_at IS NULL
-		ORDER BY created_at DESC
-	`)
+	parentRows, err := r.DB.QueryContext(ctx, "SELECT id, COALESCE(name, ''), COALESCE(image_data, ''), COALESCE(natural_width, 0), COALESCE(natural_height, 0), parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at FROM maps WHERE parent_map_id IS NULL AND deleted_at IS NULL ORDER BY created_at DESC")
 	if err != nil {
 		return nil, err
 	}
@@ -220,17 +213,9 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 		var deletedAtN sql.NullTime
 
 		if err := parentRows.Scan(
-			&base.ID,
-			&base.Name,
-			&imgStr,
-			&base.NaturalWidth,
-			&base.NaturalHeight,
-			&parentNS,
-			&base.HasFloors,
-			&base.FloorCount,
-			&base.CreatedAt,
-			&base.ModifiedAt,
-			&deletedAtN,
+			&base.ID, &base.Name, &imgStr, &base.NaturalWidth, &base.NaturalHeight,
+			&parentNS, &base.HasFloors, &base.FloorCount,
+			&base.CreatedAt, &base.ModifiedAt, &deletedAtN,
 		); err != nil {
 			return nil, err
 		}
@@ -264,13 +249,7 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 	}
 
 	// 子件数
-	cntQuery, cntArgs := buildParentInQuery(`
-		SELECT parent_map_id, COUNT(*)
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN ({{IN}})
-		GROUP BY parent_map_id
-	`, parentIDs)
+	cntQuery, cntArgs := buildParentInQuery("SELECT parent_map_id, COUNT(*) FROM maps WHERE deleted_at IS NULL AND parent_map_id IN ({{IN}}) GROUP BY parent_map_id", parentIDs)
 	cntRows, err := r.DB.QueryContext(ctx, cntQuery, cntArgs...)
 	if err != nil {
 		return nil, err
@@ -291,13 +270,7 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 	}
 
 	// 子の軽量一覧
-	childQuery, childArgs := buildParentInQuery(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN ({{IN}})
-		ORDER BY name ASC
-	`, parentIDs)
+	childQuery, childArgs := buildParentInQuery("SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id FROM maps WHERE deleted_at IS NULL AND parent_map_id IN ({{IN}}) ORDER BY name ASC", parentIDs)
 	cRows, err := r.DB.QueryContext(ctx, childQuery, childArgs...)
 	if err != nil {
 		return nil, err
@@ -319,6 +292,83 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 	}
 
 	return parents, nil
+}
+
+// /maps/{mapId} GET 用（root＋全floorを一括）
+func (r *MapRepository) FindFloorStackByAnyID(ctx context.Context, anyID string) (*FloorStackResponse, error) {
+	// base を取得
+	ag, err := r.FindAggregate(ctx, anyID)
+	if err != nil {
+		return nil, err
+	}
+	if ag == nil || ag.Base == nil {
+		return nil, nil
+	}
+
+	// root を解決
+	rootID := ag.Base.ID
+	if ag.Base.ParentMapID != nil {
+		rootID = *ag.Base.ParentMapID
+	}
+
+	// root 本体
+	rootAg, err := r.FindAggregate(ctx, rootID)
+	if err != nil {
+		return nil, err
+	}
+	if rootAg == nil || rootAg.Base == nil {
+		return nil, nil
+	}
+
+	// floors（created_at 昇順=1F..）
+	rows, err := r.DB.QueryContext(ctx, `
+		SELECT
+		  id, COALESCE(name, ''), COALESCE(image_data, ''),
+		  COALESCE(natural_width, 0), COALESCE(natural_height, 0),
+		  parent_map_id, has_floors, floor_count, created_at, modified_at
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY created_at ASC, id ASC
+	`, rootID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []FloorItemDTO
+	idx := 0
+	for rows.Next() {
+		idx++
+		var m model.Map
+		var img string
+		var parentNS sql.NullString
+		if err := rows.Scan(
+			&m.ID, &m.Name, &img, &m.NaturalWidth, &m.NaturalHeight,
+			&parentNS, &m.HasFloors, &m.FloorCount, &m.CreatedAt, &m.ModifiedAt,
+		); err != nil {
+			return nil, err
+		}
+		if parentNS.Valid {
+			v := parentNS.String
+			m.ParentMapID = &v
+		}
+		m.ImageData = img
+
+		items = append(items, FloorItemDTO{
+			FloorIndex: idx, // 1F.. created_at ASC
+			Map:        *toMapResponse(&MapAggregate{Base: &m, Children: nil}),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return &FloorStackResponse{
+		RootMapID:  rootAg.Base.ID,
+		RootName:   rootAg.Base.Name,
+		FloorCount: len(items),
+		Items:      items,
+	}, nil
 }
 
 func buildParentInQuery(tmpl string, ids []string) (string, []any) {
@@ -372,25 +422,12 @@ func toMapResponse(ag *MapAggregate) *MapResponse {
 	}
 }
 
-// PATCH 更新
+//
+// ====== 更新（PATCH） ======
+//
+
 func (r *MapRepository) UpdatePartial(ctx context.Context, id string, req *MapUpdateRequest) (*MapResponse, error) {
-	row := r.DB.QueryRowContext(ctx, `
-		SELECT
-		  id,
-		  COALESCE(name, ''),
-		  COALESCE(image_data, ''),
-		  COALESCE(natural_width, 0),
-		  COALESCE(natural_height, 0),
-		  parent_map_id,
-		  has_floors,
-		  floor_count,
-		  created_at,
-		  modified_at,
-		  deleted_at
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`, id)
+	row := r.DB.QueryRowContext(ctx, "SELECT id, COALESCE(name, ''), COALESCE(image_data, ''), COALESCE(natural_width, 0), COALESCE(natural_height, 0), parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at FROM maps WHERE id = ? AND deleted_at IS NULL LIMIT 1", id)
 
 	var cur model.Map
 	var imgStr string
@@ -398,17 +435,9 @@ func (r *MapRepository) UpdatePartial(ctx context.Context, id string, req *MapUp
 	var deletedAtN sql.NullTime
 
 	if err := row.Scan(
-		&cur.ID,
-		&cur.Name,
-		&imgStr,
-		&cur.NaturalWidth,
-		&cur.NaturalHeight,
-		&parentNS,
-		&cur.HasFloors,
-		&cur.FloorCount,
-		&cur.CreatedAt,
-		&cur.ModifiedAt,
-		&deletedAtN,
+		&cur.ID, &cur.Name, &imgStr, &cur.NaturalWidth, &cur.NaturalHeight,
+		&parentNS, &cur.HasFloors, &cur.FloorCount,
+		&cur.CreatedAt, &cur.ModifiedAt, &deletedAtN,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, sql.ErrNoRows
@@ -519,7 +548,11 @@ func (r *MapRepository) UpdatePartial(ctx context.Context, id string, req *MapUp
 	return r.FindMapResponseByID(ctx, id)
 }
 
-// 再帰削除
+//
+// ====== 削除（CASCADE）／最上階削除 ======
+//
+
+// ルートを含む再帰削除（pinsも含めてCTEで削除）
 func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64, int64, error) {
 	tx, err := r.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
@@ -533,12 +566,7 @@ func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64
 	}()
 
 	var exists int
-	if err := tx.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`, rootID).Scan(&exists); err != nil {
+	if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at IS NULL LIMIT 1", rootID).Scan(&exists); err != nil {
 		_ = tx.Rollback()
 		return 0, 0, err
 	}
@@ -547,40 +575,14 @@ func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64
 		return 0, 0, sql.ErrNoRows
 	}
 
-	resPins, err := tx.ExecContext(ctx, `
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE p FROM pins p
-		JOIN submaps sm ON p.map_id = sm.id
-	`, rootID)
+	resPins, err := tx.ExecContext(ctx, "WITH RECURSIVE submaps AS (SELECT id FROM maps WHERE id = ? AND deleted_at IS NULL UNION ALL SELECT m.id FROM maps m JOIN submaps s ON m.parent_map_id = s.id WHERE m.deleted_at IS NULL) DELETE p FROM pins p JOIN submaps sm ON p.map_id = sm.id", rootID)
 	if err != nil {
 		_ = tx.Rollback()
 		return 0, 0, err
 	}
 	pinsDeleted, _ := resPins.RowsAffected()
 
-	resMaps, err := tx.ExecContext(ctx, `
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE m FROM maps m
-		JOIN submaps sm ON m.id = sm.id
-	`, rootID)
+	resMaps, err := tx.ExecContext(ctx, "WITH RECURSIVE submaps AS (SELECT id FROM maps WHERE id = ? AND deleted_at IS NULL UNION ALL SELECT m.id FROM maps m JOIN submaps s ON m.parent_map_id = s.id WHERE m.deleted_at IS NULL) DELETE m FROM maps m JOIN submaps sm ON m.id = sm.id", rootID)
 	if err != nil {
 		_ = tx.Rollback()
 		return 0, 0, err
@@ -592,6 +594,104 @@ func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64
 	}
 	return mapsDeleted, pinsDeleted, nil
 }
+
+// 最上階のみ削除可：anyID（rootでもfloorでも可）＋ floorIndex（1..floor_count）
+// floorIndex が現行 floor_count と同値のときだけ削除する。
+func (r *MapRepository) DeleteTopFloorByIndex(ctx context.Context, anyID string, floorIndex int) error {
+	if floorIndex < 1 {
+		return fmt.Errorf("floorIndex must be >= 1")
+	}
+
+	tx, err := r.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+
+	// anyID -> root 解決
+	var parentID sql.NullString
+	if err := tx.QueryRowContext(ctx, `
+		SELECT parent_map_id FROM maps WHERE id = ? AND deleted_at IS NULL FOR UPDATE
+	`, anyID).Scan(&parentID); err != nil {
+		_ = tx.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return sql.ErrNoRows
+		}
+		return err
+	}
+	rootID := anyID
+	if parentID.Valid {
+		rootID = parentID.String
+	}
+
+	// root の floor_count をロックして取得
+	var floorCount int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT floor_count FROM maps
+		WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL
+		FOR UPDATE
+	`, rootID).Scan(&floorCount); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if floorCount == 0 {
+		_ = tx.Rollback()
+		return fmt.Errorf("no floors to delete")
+	}
+	if floorIndex != floorCount {
+		_ = tx.Rollback()
+		return fmt.Errorf("only top floor (index=%d) can be deleted", floorCount)
+	}
+
+	// 削除対象 floor のID（created_at ASC の floorIndex 件目 = 最上階）
+	var targetID string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT id
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY created_at ASC, id ASC
+		 LIMIT 1 OFFSET ?
+	`, rootID, floorIndex-1).Scan(&targetID); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	// pins -> map の順に削除（FK CASCADEがあればpinsの明示削除は不要だが安全側）
+	if _, err := tx.ExecContext(ctx, `DELETE FROM pins WHERE map_id = ?`, targetID); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM maps WHERE id = ?`, targetID); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	// root を更新
+	now := time.Now().UTC()
+	hasFloors := true
+	if floorCount-1 == 0 {
+		hasFloors = false
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE maps
+		   SET floor_count = ?, has_floors = ?, modified_at = ?
+		 WHERE id = ? AND deleted_at IS NULL
+	`, floorCount-1, hasFloors, now, rootID); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}
+
+//
+// ====== ユーティリティ／Optional ======
+//
 
 func p_id(s string) string { return s }
 

--- a/services/nutfesmap-api/internal/repository/map.go
+++ b/services/nutfesmap-api/internal/repository/map.go
@@ -3,7 +3,9 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -21,6 +23,16 @@ type MapCreateRequest struct {
 	ParentMapID   *string `json:"parentMapId"`
 	HasFloors     bool    `json:"hasFloors"`
 	FloorCount    int     `json:"floorCount"    validate:"min=0"`
+}
+
+type MapUpdateRequest struct {
+	Name          OptionalString `json:"name"`
+	ImageData     OptionalString `json:"imageData"`
+	NaturalWidth  OptionalInt    `json:"naturalWidth"`
+	NaturalHeight OptionalInt    `json:"naturalHeight"`
+	ParentMapID   OptionalString `json:"parentMapId"` // ""（null相当）で親を外す
+	HasFloors     OptionalBool   `json:"hasFloors"`
+	FloorCount    OptionalInt    `json:"floorCount"`
 }
 
 // Response DTO（外部契約）
@@ -298,5 +310,230 @@ func toMapResponse(ag *MapAggregate) *MapResponse {
 	}
 }
 
+// -------- 部分更新ロジック --------
+
+// UpdatePartial は maps テーブルを部分更新し、更新後の MapResponse を返す。
+// - 指定IDが存在しない場合は (nil, sql.ErrNoRows) を返す。
+// - バリデーションエラーは (nil, ErrBadRequest) など任意のエラーで返す（ここでは fmt.Errorf を使用）。
+func (r *MapRepository) UpdatePartial(ctx context.Context, id string, req *MapUpdateRequest) (*MapResponse, error) {
+	// 1) 現在値の取得（has_floors と floor_count は整合性チェックに使う）
+	row := r.DB.QueryRowContext(ctx, `
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`, id)
+
+	var cur model.Map
+	if err := row.Scan(
+		&cur.ID, &cur.Name, &cur.ImageData, &cur.NaturalWidth, &cur.NaturalHeight,
+		&cur.ParentMapID, &cur.HasFloors, &cur.FloorCount, &cur.CreatedAt, &cur.ModifiedAt, &cur.DeletedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, sql.ErrNoRows
+		}
+		return nil, err
+	}
+
+	// 2) 更新後の値（仮）を作る（受け取っていないフィールドは現状維持）
+	newName := cur.Name
+	if req.Name.Set {
+		newName = strings.TrimSpace(req.Name.Value)
+		if len(newName) == 0 {
+			return nil, fmt.Errorf("name must not be empty")
+		}
+	}
+
+	newImage := cur.ImageData
+	if req.ImageData.Set {
+		// 画像差し替え。空文字の場合は許容しない（base64想定）。
+		if strings.TrimSpace(req.ImageData.Value) == "" {
+			return nil, fmt.Errorf("imageData must not be empty when provided")
+		}
+		newImage = req.ImageData.Value
+	}
+
+	newW := cur.NaturalWidth
+	if req.NaturalWidth.Set {
+		if req.NaturalWidth.Value < 1 {
+			return nil, fmt.Errorf("naturalWidth must be >= 1")
+		}
+		newW = req.NaturalWidth.Value
+	}
+
+	newH := cur.NaturalHeight
+	if req.NaturalHeight.Set {
+		if req.NaturalHeight.Value < 1 {
+			return nil, fmt.Errorf("naturalHeight must be >= 1")
+		}
+		newH = req.NaturalHeight.Value
+	}
+
+	// parent_map_id は ""（= JSON null）なら NULL にする
+	var parentID *string = cur.ParentMapID
+	if req.ParentMapID.Set {
+		if req.ParentMapID.Value == "" {
+			parentID = nil
+		} else {
+			val := req.ParentMapID.Value
+			parentID = &val
+		}
+	}
+
+	newHasFloors := cur.HasFloors
+	if req.HasFloors.Set {
+		newHasFloors = req.HasFloors.Value
+	}
+
+	newFloorCount := cur.FloorCount
+	if req.FloorCount.Set {
+		if req.FloorCount.Value < 0 {
+			return nil, fmt.Errorf("floorCount must be >= 0")
+		}
+		newFloorCount = req.FloorCount.Value
+	}
+
+	// hasFloors と floorCount の整合性
+	// - hasFloors=true なら floorCount>=1 を要求
+	// - hasFloors=false なら floorCount は 0 に揃える（要求がなければ自動で0にする）
+	if newHasFloors {
+		if newFloorCount < 1 {
+			return nil, fmt.Errorf("floorCount must be >= 1 when hasFloors is true")
+		}
+	} else {
+		newFloorCount = 0
+	}
+
+	// 3) 実際に変更があるフィールドだけ UPDATE を組み立てる
+	set := make([]string, 0, 8)
+	args := make([]any, 0, 9)
+
+	if req.Name.Set && newName != cur.Name {
+		set = append(set, "name = ?")
+		args = append(args, newName)
+	}
+	if req.ImageData.Set && newImage != cur.ImageData {
+		set = append(set, "image_data = ?")
+		args = append(args, newImage)
+	}
+	if req.NaturalWidth.Set && newW != cur.NaturalWidth {
+		set = append(set, "natural_width = ?")
+		args = append(args, newW)
+	}
+	if req.NaturalHeight.Set && newH != cur.NaturalHeight {
+		set = append(set, "natural_height = ?")
+		args = append(args, newH)
+	}
+	if req.ParentMapID.Set {
+		if parentID == nil {
+			set = append(set, "parent_map_id = NULL")
+		} else {
+			set = append(set, "parent_map_id = ?")
+			args = append(args, *parentID)
+		}
+	}
+	// has_floors / floor_count はセットの有無にかかわらず、上で整合済みの new* と現状が違うなら反映
+	if newHasFloors != cur.HasFloors {
+		set = append(set, "has_floors = ?")
+		args = append(args, newHasFloors)
+	}
+	if newFloorCount != cur.FloorCount {
+		set = append(set, "floor_count = ?")
+		args = append(args, newFloorCount)
+	}
+
+	// 変更なしならそのまま現在のレスポンスを返す
+	if len(set) == 0 {
+		return toMapResponse(&MapAggregate{
+			Base:          &cur,
+			ChildrenCount: 0, // 下で再取得するのでここは未使用
+			Children:      []model.MapChildRef{},
+		}), nil
+	}
+
+	// modified_at 更新
+	set = append(set, "modified_at = ?")
+	now := time.Now().UTC()
+	args = append(args, now)
+
+	// WHERE
+	args = append(args, id)
+
+	q := "UPDATE maps SET " + strings.Join(set, ", ") + " WHERE id = ? AND deleted_at IS NULL"
+	res, err := r.DB.ExecContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	aff, _ := res.RowsAffected()
+	if aff == 0 {
+		// 競合的に消された、等
+		return nil, sql.ErrNoRows
+	}
+
+	// 4) 更新後の統合レスポンスを返す
+	return r.FindMapResponseByID(ctx, id)
+}
+
 // p_id: プレーンな親IDを返すだけ（将来の前処理フック用に分離）
 func p_id(s string) string { return s }
+
+// -------- Optional ユーティリティ（JSONで「指定されたか」を判定するための型） --------
+
+type OptionalString struct {
+	Set   bool
+	Value string
+}
+
+func (o *OptionalString) UnmarshalJSON(b []byte) error {
+	o.Set = true
+	// null の場合は空文字のまま Set=true にしておく（空文字は NULL にしたい箇所で解釈）
+	if string(b) == "null" {
+		o.Value = ""
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	o.Value = s
+	return nil
+}
+
+type OptionalInt struct {
+	Set   bool
+	Value int
+}
+
+func (o *OptionalInt) UnmarshalJSON(b []byte) error {
+	o.Set = true
+	if string(b) == "null" {
+		o.Value = 0
+		return nil
+	}
+	var n int
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	o.Value = n
+	return nil
+}
+
+type OptionalBool struct {
+	Set   bool
+	Value bool
+}
+
+func (o *OptionalBool) UnmarshalJSON(b []byte) error {
+	o.Set = true
+	if string(b) == "null" {
+		o.Value = false
+		return nil
+	}
+	var v bool
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	o.Value = v
+	return nil
+}

--- a/services/nutfesmap-api/internal/repository/map.go
+++ b/services/nutfesmap-api/internal/repository/map.go
@@ -252,5 +252,51 @@ func buildParentInQuery(tmpl string, ids []string) (string, []any) {
 	return q, args
 }
 
+// --- 地図メタ取得（/maps/{mapId} GET）用: Aggregate -> Response 変換付きの取得関数を追加 ---
+
+// FindMapResponseByID は、指定IDの Map 本体と直下の子メタ情報をまとめて取得し、外部契約DTOに整形して返す。
+// 見つからなかった場合は (nil, nil) を返す。
+func (r *MapRepository) FindMapResponseByID(ctx context.Context, id string) (*MapResponse, error) {
+	ag, err := r.FindAggregate(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if ag == nil || ag.Base == nil {
+		return nil, nil
+	}
+	return toMapResponse(ag), nil
+}
+
+// 内部: MapAggregate を MapResponse に詰め替える
+func toMapResponse(ag *MapAggregate) *MapResponse {
+	base := ag.Base
+
+	// 子の軽量一覧を DTO に詰め替え
+	children := make([]MapChildRefDTO, 0, len(ag.Children))
+	for _, c := range ag.Children {
+		children = append(children, MapChildRefDTO{
+			ID:         c.ID,
+			Name:       c.Name,
+			HasFloors:  c.HasFloors,
+			FloorCount: c.FloorCount,
+		})
+	}
+
+	return &MapResponse{
+		ID:            base.ID,
+		Name:          base.Name,
+		ImageData:     base.ImageData,
+		NaturalWidth:  base.NaturalWidth,
+		NaturalHeight: base.NaturalHeight,
+		ParentMapID:   base.ParentMapID,
+		HasFloors:     base.HasFloors,
+		FloorCount:    base.FloorCount,
+		ChildrenCount: ag.ChildrenCount,
+		Children:      children,
+		CreatedAt:     base.CreatedAt,
+		ModifiedAt:    base.ModifiedAt,
+	}
+}
+
 // p_id: プレーンな親IDを返すだけ（将来の前処理フック用に分離）
 func p_id(s string) string { return s }

--- a/services/nutfesmap-api/internal/repository/map.go
+++ b/services/nutfesmap-api/internal/repository/map.go
@@ -14,15 +14,8 @@ import (
 
 type MapRepository struct{ DB *sql.DB }
 
-// Request DTO（外部契約）
 type MapCreateRequest struct {
-	Name          string  `json:"name"          validate:"required,min=1"`
-	ImageData     string  `json:"imageData"     validate:"required"` // base64
-	NaturalWidth  int     `json:"naturalWidth"  validate:"required,min=1"`
-	NaturalHeight int     `json:"naturalHeight" validate:"required,min=1"`
-	ParentMapID   *string `json:"parentMapId"`
-	HasFloors     bool    `json:"hasFloors"`
-	FloorCount    int     `json:"floorCount"    validate:"min=0"`
+	ParentMapID *string `json:"parentMapId"`
 }
 
 type MapUpdateRequest struct {
@@ -30,12 +23,9 @@ type MapUpdateRequest struct {
 	ImageData     OptionalString `json:"imageData"`
 	NaturalWidth  OptionalInt    `json:"naturalWidth"`
 	NaturalHeight OptionalInt    `json:"naturalHeight"`
-	ParentMapID   OptionalString `json:"parentMapId"` // ""（null相当）で親を外す
-	HasFloors     OptionalBool   `json:"hasFloors"`
-	FloorCount    OptionalInt    `json:"floorCount"`
+	ParentMapID   OptionalString `json:"parentMapId"`
 }
 
-// Response DTO（外部契約）
 type MapChildRefDTO struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
@@ -60,22 +50,44 @@ type MapResponse struct {
 
 func NewMapRepository(db *sql.DB) *MapRepository { return &MapRepository{DB: db} }
 
-// 1件挿入
-func (r *MapRepository) Insert(ctx context.Context, m *model.Map) error {
+// 作成（空マップ）: name=""、image_data=NULL、natural_*=0
+func (r *MapRepository) CreateEmpty(ctx context.Context, id string, parentID *string) error {
 	now := time.Now().UTC()
+
+	var parent any
+	if parentID == nil {
+		parent = nil
+	} else {
+		parent = *parentID
+	}
+
 	_, err := r.DB.ExecContext(ctx, `
 		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height,
-			parent_map_id, has_floors, floor_count, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?,?,?)
-	`,
-		m.ID, m.Name, m.ImageData, m.NaturalWidth, m.NaturalHeight,
-		m.ParentMapID, m.HasFloors, m.FloorCount, now, now,
-	)
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
+	`, id, "", nil, 0, 0, parent, now, now)
 	return err
 }
 
-// 本体 + 子の件数 + 子の軽量一覧をまとめて取得（レスポンス組み立て向け）
+// 既存互換（最小挿入）
+func (r *MapRepository) Insert(ctx context.Context, m *model.Map) error {
+	now := time.Now().UTC()
+
+	var parent any
+	if m.ParentMapID == nil {
+		parent = nil
+	} else {
+		parent = *m.ParentMapID
+	}
+
+	_, err := r.DB.ExecContext(ctx, `
+		INSERT INTO maps (
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
+	`, m.ID, "", nil, 0, 0, parent, now, now)
+	return err
+}
+
 type MapAggregate struct {
 	Base          *model.Map
 	ChildrenCount int
@@ -84,25 +96,58 @@ type MapAggregate struct {
 
 func (r *MapRepository) FindAggregate(ctx context.Context, id string) (*MapAggregate, error) {
 	row := r.DB.QueryRowContext(ctx, `
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		SELECT
+		  id,
+		  COALESCE(name, ''),
+		  COALESCE(image_data, ''),
+		  COALESCE(natural_width, 0),
+		  COALESCE(natural_height, 0),
+		  parent_map_id,
+		  has_floors,
+		  floor_count,
+		  created_at,
+		  modified_at,
+		  deleted_at
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`, id)
 
 	var base model.Map
+	var imgStr string
+	var parentNS sql.NullString
+	var deletedAtN sql.NullTime
+
 	if err := row.Scan(
-		&base.ID, &base.Name, &base.ImageData, &base.NaturalWidth, &base.NaturalHeight,
-		&base.ParentMapID, &base.HasFloors, &base.FloorCount, &base.CreatedAt, &base.ModifiedAt, &base.DeletedAt,
+		&base.ID,
+		&base.Name,
+		&imgStr,
+		&base.NaturalWidth,
+		&base.NaturalHeight,
+		&parentNS,
+		&base.HasFloors,
+		&base.FloorCount,
+		&base.CreatedAt,
+		&base.ModifiedAt,
+		&deletedAtN,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
 	}
+	if parentNS.Valid {
+		v := parentNS.String
+		base.ParentMapID = &v
+	}
+	if deletedAtN.Valid {
+		t := deletedAtN.Time
+		base.DeletedAt = &t
+	}
+	// LONGTEXTはそのまま返す
+	base.ImageData = imgStr
 
-	// 子の件数
+	// 子件数
 	var cnt int
 	if err := r.DB.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
@@ -110,12 +155,12 @@ func (r *MapRepository) FindAggregate(ctx context.Context, id string) (*MapAggre
 		return nil, err
 	}
 
-	// 子の軽量一覧
+	// 子一覧
 	rows, err := r.DB.QueryContext(ctx, `
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`, base.ID)
 	if err != nil {
 		return nil, err
@@ -130,6 +175,9 @@ func (r *MapRepository) FindAggregate(ctx context.Context, id string) (*MapAggre
 		}
 		children = append(children, c)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return &MapAggregate{
 		Base:          &base,
@@ -138,16 +186,25 @@ func (r *MapRepository) FindAggregate(ctx context.Context, id string) (*MapAggre
 	}, nil
 }
 
-// 親マップ（parent_map_id IS NULL）をまとめて取得し、各親の ChildrenCount と Children を埋めて返す
+// 親（root）一覧と子の簡易情報
 func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregate, error) {
-	// 1) 親一覧（削除されていない最上位マップ）
 	parentRows, err := r.DB.QueryContext(ctx, `
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE parent_map_id IS NULL
-		   AND deleted_at IS NULL
-		 ORDER BY created_at DESC
+		SELECT
+		  id,
+		  COALESCE(name, ''),
+		  COALESCE(image_data, ''),
+		  COALESCE(natural_width, 0),
+		  COALESCE(natural_height, 0),
+		  parent_map_id,
+		  has_floors,
+		  floor_count,
+		  created_at,
+		  modified_at,
+		  deleted_at
+		FROM maps
+		WHERE parent_map_id IS NULL
+		  AND deleted_at IS NULL
+		ORDER BY created_at DESC
 	`)
 	if err != nil {
 		return nil, err
@@ -156,15 +213,37 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 
 	var parents []*MapAggregate
 	var parentIDs []string
-
 	for parentRows.Next() {
 		var base model.Map
+		var imgStr string
+		var parentNS sql.NullString
+		var deletedAtN sql.NullTime
+
 		if err := parentRows.Scan(
-			&base.ID, &base.Name, &base.ImageData, &base.NaturalWidth, &base.NaturalHeight,
-			&base.ParentMapID, &base.HasFloors, &base.FloorCount, &base.CreatedAt, &base.ModifiedAt, &base.DeletedAt,
+			&base.ID,
+			&base.Name,
+			&imgStr,
+			&base.NaturalWidth,
+			&base.NaturalHeight,
+			&parentNS,
+			&base.HasFloors,
+			&base.FloorCount,
+			&base.CreatedAt,
+			&base.ModifiedAt,
+			&deletedAtN,
 		); err != nil {
 			return nil, err
 		}
+		if parentNS.Valid {
+			v := parentNS.String
+			base.ParentMapID = &v
+		}
+		if deletedAtN.Valid {
+			t := deletedAtN.Time
+			base.DeletedAt = &t
+		}
+		base.ImageData = imgStr
+
 		parents = append(parents, &MapAggregate{
 			Base:          &base,
 			ChildrenCount: 0,
@@ -179,35 +258,31 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 		return parents, nil
 	}
 
-	// parentID -> Aggregate のインデックス
 	parentIdx := make(map[string]*MapAggregate, len(parents))
 	for _, ag := range parents {
 		parentIdx[ag.Base.ID] = ag
 	}
 
-	// 2) 子件数を一括で取得
-	// SELECT parent_map_id, COUNT(*) FROM maps WHERE parent_map_id IN (...) AND deleted_at IS NULL GROUP BY parent_map_id;
+	// 子件数
 	cntQuery, cntArgs := buildParentInQuery(`
 		SELECT parent_map_id, COUNT(*)
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN ({{IN}})
-		 GROUP BY parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN ({{IN}})
+		GROUP BY parent_map_id
 	`, parentIDs)
-
 	cntRows, err := r.DB.QueryContext(ctx, cntQuery, cntArgs...)
 	if err != nil {
 		return nil, err
 	}
 	defer cntRows.Close()
-
 	for cntRows.Next() {
 		var pid string
 		var cnt int
 		if err := cntRows.Scan(&pid, &cnt); err != nil {
 			return nil, err
 		}
-		if ag, ok := parentIdx[p_id(pid)]; ok { // p_id は下のヘルパ（単純に戻すだけ）
+		if ag, ok := parentIdx[p_id(pid)]; ok {
 			ag.ChildrenCount = cnt
 		}
 	}
@@ -215,16 +290,14 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 		return nil, err
 	}
 
-	// 3) 子の軽量一覧を一括で取得
-	// SELECT id, name, has_floors, floor_count, parent_map_id FROM maps WHERE parent_map_id IN (...) AND deleted_at IS NULL ORDER BY name;
+	// 子の軽量一覧
 	childQuery, childArgs := buildParentInQuery(`
-		SELECT id, name, has_floors, floor_count, parent_map_id
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN ({{IN}})
-		 ORDER BY name ASC
+		SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN ({{IN}})
+		ORDER BY name ASC
 	`, parentIDs)
-
 	cRows, err := r.DB.QueryContext(ctx, childQuery, childArgs...)
 	if err != nil {
 		return nil, err
@@ -248,15 +321,12 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 	return parents, nil
 }
 
-// 親IDの IN 句を安全に生成するヘルパ
-// tmpl 内の "{{IN}}" を "?, ?, ?" に置換し、引数スライスを返す
 func buildParentInQuery(tmpl string, ids []string) (string, []any) {
 	if len(ids) == 0 {
-		// 呼び出し側でゼロ件を弾いているのでここには通常来ないが、念のため
 		return strings.ReplaceAll(tmpl, "{{IN}}", "NULL"), nil
 	}
-	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
-	q := strings.ReplaceAll(tmpl, "{{IN}}", placeholders)
+	ph := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
+	q := strings.ReplaceAll(tmpl, "{{IN}}", ph)
 	args := make([]any, len(ids))
 	for i, id := range ids {
 		args[i] = id
@@ -264,10 +334,6 @@ func buildParentInQuery(tmpl string, ids []string) (string, []any) {
 	return q, args
 }
 
-// --- 地図メタ取得（/maps/{mapId} GET）用: Aggregate -> Response 変換付きの取得関数を追加 ---
-
-// FindMapResponseByID は、指定IDの Map 本体と直下の子メタ情報をまとめて取得し、外部契約DTOに整形して返す。
-// 見つからなかった場合は (nil, nil) を返す。
 func (r *MapRepository) FindMapResponseByID(ctx context.Context, id string) (*MapResponse, error) {
 	ag, err := r.FindAggregate(ctx, id)
 	if err != nil {
@@ -279,11 +345,8 @@ func (r *MapRepository) FindMapResponseByID(ctx context.Context, id string) (*Ma
 	return toMapResponse(ag), nil
 }
 
-// 内部: MapAggregate を MapResponse に詰め替える
 func toMapResponse(ag *MapAggregate) *MapResponse {
 	base := ag.Base
-
-	// 子の軽量一覧を DTO に詰め替え
 	children := make([]MapChildRefDTO, 0, len(ag.Children))
 	for _, c := range ag.Children {
 		children = append(children, MapChildRefDTO{
@@ -293,7 +356,6 @@ func toMapResponse(ag *MapAggregate) *MapResponse {
 			FloorCount: c.FloorCount,
 		})
 	}
-
 	return &MapResponse{
 		ID:            base.ID,
 		Name:          base.Name,
@@ -303,51 +365,76 @@ func toMapResponse(ag *MapAggregate) *MapResponse {
 		ParentMapID:   base.ParentMapID,
 		HasFloors:     base.HasFloors,
 		FloorCount:    base.FloorCount,
-		ChildrenCount: ag.ChildrenCount,
+		ChildrenCount: len(ag.Children),
 		Children:      children,
 		CreatedAt:     base.CreatedAt,
 		ModifiedAt:    base.ModifiedAt,
 	}
 }
 
-// -------- 部分更新ロジック --------
-
-// UpdatePartial は maps テーブルを部分更新し、更新後の MapResponse を返す。
-// - 指定IDが存在しない場合は (nil, sql.ErrNoRows) を返す。
-// - バリデーションエラーは (nil, ErrBadRequest) など任意のエラーで返す（ここでは fmt.Errorf を使用）。
+// PATCH 更新
 func (r *MapRepository) UpdatePartial(ctx context.Context, id string, req *MapUpdateRequest) (*MapResponse, error) {
-	// 1) 現在値の取得（has_floors と floor_count は整合性チェックに使う）
 	row := r.DB.QueryRowContext(ctx, `
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		SELECT
+		  id,
+		  COALESCE(name, ''),
+		  COALESCE(image_data, ''),
+		  COALESCE(natural_width, 0),
+		  COALESCE(natural_height, 0),
+		  parent_map_id,
+		  has_floors,
+		  floor_count,
+		  created_at,
+		  modified_at,
+		  deleted_at
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`, id)
 
 	var cur model.Map
+	var imgStr string
+	var parentNS sql.NullString
+	var deletedAtN sql.NullTime
+
 	if err := row.Scan(
-		&cur.ID, &cur.Name, &cur.ImageData, &cur.NaturalWidth, &cur.NaturalHeight,
-		&cur.ParentMapID, &cur.HasFloors, &cur.FloorCount, &cur.CreatedAt, &cur.ModifiedAt, &cur.DeletedAt,
+		&cur.ID,
+		&cur.Name,
+		&imgStr,
+		&cur.NaturalWidth,
+		&cur.NaturalHeight,
+		&parentNS,
+		&cur.HasFloors,
+		&cur.FloorCount,
+		&cur.CreatedAt,
+		&cur.ModifiedAt,
+		&deletedAtN,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, sql.ErrNoRows
 		}
 		return nil, err
 	}
+	if parentNS.Valid {
+		v := parentNS.String
+		cur.ParentMapID = &v
+	}
+	if deletedAtN.Valid {
+		t := deletedAtN.Time
+		cur.DeletedAt = &t
+	}
+	cur.ImageData = imgStr
 
-	// 2) 更新後の値（仮）を作る（受け取っていないフィールドは現状維持）
 	newName := cur.Name
 	if req.Name.Set {
 		newName = strings.TrimSpace(req.Name.Value)
-		if len(newName) == 0 {
+		if newName == "" {
 			return nil, fmt.Errorf("name must not be empty")
 		}
 	}
 
 	newImage := cur.ImageData
 	if req.ImageData.Set {
-		// 画像差し替え。空文字の場合は許容しない（base64想定）。
 		if strings.TrimSpace(req.ImageData.Value) == "" {
 			return nil, fmt.Errorf("imageData must not be empty when provided")
 		}
@@ -370,44 +457,18 @@ func (r *MapRepository) UpdatePartial(ctx context.Context, id string, req *MapUp
 		newH = req.NaturalHeight.Value
 	}
 
-	// parent_map_id は ""（= JSON null）なら NULL にする
 	var parentID *string = cur.ParentMapID
 	if req.ParentMapID.Set {
 		if req.ParentMapID.Value == "" {
 			parentID = nil
 		} else {
-			val := req.ParentMapID.Value
-			parentID = &val
+			v := req.ParentMapID.Value
+			parentID = &v
 		}
 	}
 
-	newHasFloors := cur.HasFloors
-	if req.HasFloors.Set {
-		newHasFloors = req.HasFloors.Value
-	}
-
-	newFloorCount := cur.FloorCount
-	if req.FloorCount.Set {
-		if req.FloorCount.Value < 0 {
-			return nil, fmt.Errorf("floorCount must be >= 0")
-		}
-		newFloorCount = req.FloorCount.Value
-	}
-
-	// hasFloors と floorCount の整合性
-	// - hasFloors=true なら floorCount>=1 を要求
-	// - hasFloors=false なら floorCount は 0 に揃える（要求がなければ自動で0にする）
-	if newHasFloors {
-		if newFloorCount < 1 {
-			return nil, fmt.Errorf("floorCount must be >= 1 when hasFloors is true")
-		}
-	} else {
-		newFloorCount = 0
-	}
-
-	// 3) 実際に変更があるフィールドだけ UPDATE を組み立てる
-	set := make([]string, 0, 8)
-	args := make([]any, 0, 9)
+	set := make([]string, 0, 6)
+	args := make([]any, 0, 8)
 
 	if req.Name.Set && newName != cur.Name {
 		set = append(set, "name = ?")
@@ -433,74 +494,50 @@ func (r *MapRepository) UpdatePartial(ctx context.Context, id string, req *MapUp
 			args = append(args, *parentID)
 		}
 	}
-	// has_floors / floor_count はセットの有無にかかわらず、上で整合済みの new* と現状が違うなら反映
-	if newHasFloors != cur.HasFloors {
-		set = append(set, "has_floors = ?")
-		args = append(args, newHasFloors)
-	}
-	if newFloorCount != cur.FloorCount {
-		set = append(set, "floor_count = ?")
-		args = append(args, newFloorCount)
-	}
 
-	// 変更なしならそのまま現在のレスポンスを返す
 	if len(set) == 0 {
 		return toMapResponse(&MapAggregate{
 			Base:          &cur,
-			ChildrenCount: 0, // 下で再取得するのでここは未使用
+			ChildrenCount: 0,
 			Children:      []model.MapChildRef{},
 		}), nil
 	}
 
-	// modified_at 更新
 	set = append(set, "modified_at = ?")
 	now := time.Now().UTC()
-	args = append(args, now)
-
-	// WHERE
-	args = append(args, id)
+	args = append(args, now, id)
 
 	q := "UPDATE maps SET " + strings.Join(set, ", ") + " WHERE id = ? AND deleted_at IS NULL"
 	res, err := r.DB.ExecContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
-	aff, _ := res.RowsAffected()
-	if aff == 0 {
-		// 競合的に消された、等
+	if aff, _ := res.RowsAffected(); aff == 0 {
 		return nil, sql.ErrNoRows
 	}
 
-	// 4) 更新後の統合レスポンスを返す
 	return r.FindMapResponseByID(ctx, id)
 }
 
-// DeleteCascade は、指定 mapId のマップと、その配下の全ての子マップ・各マップに紐づくピンを再帰的に削除する。
-// - 削除対象が存在しなければ sql.ErrNoRows を返す
-// - 成功時は (mapsDeleted, pinsDeleted, nil) を返す
-// 注意: 物理削除（DELETE）です。FKで ON DELETE CASCADE を張っている場合は pins の明示削除は不要だが、
-//
-//	DB設定に依存しないよう先に pins を明示的に削除してから maps を削除している。
+// 再帰削除
 func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64, int64, error) {
 	tx, err := r.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return 0, 0, err
 	}
 	defer func() {
-		// パニック時ロールバック
 		if p := recover(); p != nil {
 			_ = tx.Rollback()
 			panic(p)
 		}
 	}()
 
-	// 1) 対象存在チェック（deleted_at IS NULL のアクティブなもの）
 	var exists int
 	if err := tx.QueryRowContext(ctx, `
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`, rootID).Scan(&exists); err != nil {
 		_ = tx.Rollback()
 		return 0, 0, err
@@ -510,18 +547,16 @@ func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64
 		return 0, 0, sql.ErrNoRows
 	}
 
-	// 2) pins を削除（対象サブツリーに属する map_id のみ）
-	//    再帰CTEで配下のID集合を構築
 	resPins, err := tx.ExecContext(ctx, `
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE p FROM pins p
 		JOIN submaps sm ON p.map_id = sm.id
@@ -532,17 +567,16 @@ func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64
 	}
 	pinsDeleted, _ := resPins.RowsAffected()
 
-	// 3) maps を削除（サブツリー全体）
 	resMaps, err := tx.ExecContext(ctx, `
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE m FROM maps m
 		JOIN submaps sm ON m.id = sm.id
@@ -559,11 +593,9 @@ func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64
 	return mapsDeleted, pinsDeleted, nil
 }
 
-// p_id: プレーンな親IDを返すだけ（将来の前処理フック用に分離）
 func p_id(s string) string { return s }
 
-// -------- Optional ユーティリティ（JSONで「指定されたか」を判定するための型） --------
-
+// Optional types
 type OptionalString struct {
 	Set   bool
 	Value string
@@ -571,7 +603,6 @@ type OptionalString struct {
 
 func (o *OptionalString) UnmarshalJSON(b []byte) error {
 	o.Set = true
-	// null の場合は空文字のまま Set=true にしておく（空文字は NULL にしたい箇所で解釈）
 	if string(b) == "null" {
 		o.Value = ""
 		return nil
@@ -600,24 +631,5 @@ func (o *OptionalInt) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	o.Value = n
-	return nil
-}
-
-type OptionalBool struct {
-	Set   bool
-	Value bool
-}
-
-func (o *OptionalBool) UnmarshalJSON(b []byte) error {
-	o.Set = true
-	if string(b) == "null" {
-		o.Value = false
-		return nil
-	}
-	var v bool
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	o.Value = v
 	return nil
 }

--- a/services/nutfesmap-api/internal/repository/map.go
+++ b/services/nutfesmap-api/internal/repository/map.go
@@ -475,6 +475,90 @@ func (r *MapRepository) UpdatePartial(ctx context.Context, id string, req *MapUp
 	return r.FindMapResponseByID(ctx, id)
 }
 
+// DeleteCascade は、指定 mapId のマップと、その配下の全ての子マップ・各マップに紐づくピンを再帰的に削除する。
+// - 削除対象が存在しなければ sql.ErrNoRows を返す
+// - 成功時は (mapsDeleted, pinsDeleted, nil) を返す
+// 注意: 物理削除（DELETE）です。FKで ON DELETE CASCADE を張っている場合は pins の明示削除は不要だが、
+//
+//	DB設定に依存しないよう先に pins を明示的に削除してから maps を削除している。
+func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64, int64, error) {
+	tx, err := r.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() {
+		// パニック時ロールバック
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+
+	// 1) 対象存在チェック（deleted_at IS NULL のアクティブなもの）
+	var exists int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`, rootID).Scan(&exists); err != nil {
+		_ = tx.Rollback()
+		return 0, 0, err
+	}
+	if exists == 0 {
+		_ = tx.Rollback()
+		return 0, 0, sql.ErrNoRows
+	}
+
+	// 2) pins を削除（対象サブツリーに属する map_id のみ）
+	//    再帰CTEで配下のID集合を構築
+	resPins, err := tx.ExecContext(ctx, `
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE p FROM pins p
+		JOIN submaps sm ON p.map_id = sm.id
+	`, rootID)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, 0, err
+	}
+	pinsDeleted, _ := resPins.RowsAffected()
+
+	// 3) maps を削除（サブツリー全体）
+	resMaps, err := tx.ExecContext(ctx, `
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE m FROM maps m
+		JOIN submaps sm ON m.id = sm.id
+	`, rootID)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, 0, err
+	}
+	mapsDeleted, _ := resMaps.RowsAffected()
+
+	if err := tx.Commit(); err != nil {
+		return 0, 0, err
+	}
+	return mapsDeleted, pinsDeleted, nil
+}
+
 // p_id: プレーンな親IDを返すだけ（将来の前処理フック用に分離）
 func p_id(s string) string { return s }
 

--- a/services/nutfesmap-api/internal/repository/map.go
+++ b/services/nutfesmap-api/internal/repository/map.go
@@ -73,8 +73,7 @@ type FloorStackResponse struct {
 // ====== 作成（root/floor） ======
 //
 
-// CreateEmptyMapTx: parentID=nil なら root を作成、非nilなら floor を作成し root の集約値を更新。
-// 外からは CreateByRequest を使う想定。
+// 既存 CreateEmptyMapTx は「汎用の子/ルート作成（集約値を更新しない）」に変更
 func (r *MapRepository) CreateEmptyMapTx(ctx context.Context, id string, parentID *string) error {
 	tx, err := r.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
@@ -89,37 +88,94 @@ func (r *MapRepository) CreateEmptyMapTx(ctx context.Context, id string, parentI
 
 	now := time.Now().UTC()
 
-	// floor の場合は root の存在チェック（FOR UPDATE）
+	// 親指定がある場合は、親の存在だけを検証（親が root である必要はない）
 	if parentID != nil {
 		var cnt int
-		if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM maps WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL FOR UPDATE", *parentID).Scan(&cnt); err != nil {
+		if err := tx.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at IS NULL FOR UPDATE",
+			*parentID,
+		).Scan(&cnt); err != nil {
 			_ = tx.Rollback()
 			return err
 		}
 		if cnt == 0 {
 			_ = tx.Rollback()
-			return fmt.Errorf("parent root not found: %s", *parentID)
+			return fmt.Errorf("parent not found: %s", *parentID)
 		}
 	}
 
-	// INSERT（has_floors=false, floor_count=0 を明示）
 	var parent any
 	if parentID == nil {
 		parent = nil
 	} else {
 		parent = *parentID
 	}
-	if _, err := tx.ExecContext(ctx, "INSERT INTO maps (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at) VALUES (?,?,?,?,?,?,?,?,?,?)", id, "", nil, 0, 0, parent, false, 0, now, now); err != nil {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO maps
+		  (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?)`,
+		id, "", nil, 0, 0, parent, false, 0, now, now,
+	); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
 
-	// floor 追加時は親 root を更新
-	if parentID != nil {
-		if _, err := tx.ExecContext(ctx, "UPDATE maps SET has_floors = TRUE, floor_count = floor_count + 1, modified_at = ? WHERE id = ? AND deleted_at IS NULL", now, *parentID); err != nil {
+	return tx.Commit()
+}
+
+// 新規追加: フロア専用の作成（親＝フロアのルート：通常はエリア）
+// 親の has_floors=true, floor_count++ を更新する
+func (r *MapRepository) CreateEmptyFloorTx(ctx context.Context, id string, floorRootID string) error {
+	tx, err := r.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+
+	now := time.Now().UTC()
+
+	// フロア親（=フロアスタックのルート＝エリア）の存在チェック（FOR UPDATE）
+	{
+		var cnt int
+		if err := tx.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at IS NULL FOR UPDATE",
+			floorRootID,
+		).Scan(&cnt); err != nil {
 			_ = tx.Rollback()
 			return err
 		}
+		if cnt == 0 {
+			_ = tx.Rollback()
+			return fmt.Errorf("floor root not found: %s", floorRootID)
+		}
+	}
+
+	// フロア（空Map）を挿入（parent_map_id = floorRootID）
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO maps
+		  (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?)`,
+		id, "", nil, 0, 0, floorRootID, false, 0, now, now,
+	); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	// 親（エリア）を更新
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE maps
+		   SET has_floors = TRUE,
+		       floor_count = floor_count + 1,
+		       modified_at = ?
+		 WHERE id = ? AND deleted_at IS NULL
+	`, now, floorRootID); err != nil {
+		_ = tx.Rollback()
+		return err
 	}
 
 	return tx.Commit()
@@ -127,7 +183,66 @@ func (r *MapRepository) CreateEmptyMapTx(ctx context.Context, id string, parentI
 
 // 仕様に合わせた入口: /maps POST および /maps/{id}/floors POST の実体
 func (r *MapRepository) CreateByRequest(ctx context.Context, newID string, req *MapCreateRequest) error {
-	return r.CreateEmptyMapTx(ctx, newID, req.ParentMapID)
+	tx, err := r.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+
+	now := time.Now().UTC()
+
+	// 親なし（=root作成）
+	if req.ParentMapID == nil {
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO maps (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+			newID, "", nil, 0, 0, nil, false, 0, now, now,
+		); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		return tx.Commit()
+	}
+
+	// 親あり（=floor作成）。親の存在チェック + FOR UPDATE
+	{
+		var cnt int
+		if err := tx.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at IS NULL FOR UPDATE",
+			*req.ParentMapID,
+		).Scan(&cnt); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if cnt == 0 {
+			_ = tx.Rollback()
+			return fmt.Errorf("parent not found: %s", *req.ParentMapID)
+		}
+	}
+
+	// floor の INSERT
+	if _, err := tx.ExecContext(ctx,
+		"INSERT INTO maps (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+		newID, "", nil, 0, 0, *req.ParentMapID, false, 0, now, now,
+	); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	// 親の集約更新（has_floors=true, floor_count+1）
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE maps SET has_floors = TRUE, floor_count = floor_count + 1, modified_at = ? WHERE id = ? AND deleted_at IS NULL",
+		now, *req.ParentMapID,
+	); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
 }
 
 //
@@ -294,9 +409,9 @@ func (r *MapRepository) FindIndexAggregates(ctx context.Context) ([]*MapAggregat
 	return parents, nil
 }
 
-// /maps/{mapId} GET 用（root＋全floorを一括）
+// anyID がエリア(root)ならその直下、フロアならその親エリア直下を 1F.. の順で返す
 func (r *MapRepository) FindFloorStackByAnyID(ctx context.Context, anyID string) (*FloorStackResponse, error) {
-	// base を取得
+	// 1) anyID の aggregate をまず読む（ここで floor の場合は子件数=0 の想定）
 	ag, err := r.FindAggregate(ctx, anyID)
 	if err != nil {
 		return nil, err
@@ -305,22 +420,24 @@ func (r *MapRepository) FindFloorStackByAnyID(ctx context.Context, anyID string)
 		return nil, nil
 	}
 
-	// root を解決
-	rootID := ag.Base.ID
+	// 2) floorRoot を決定
+	//    - anyID が floor のとき: 親が root なので parent を root とする
+	//    - anyID が root のとき: そのまま anyID が root
+	floorRootID := anyID
 	if ag.Base.ParentMapID != nil {
-		rootID = *ag.Base.ParentMapID
+		floorRootID = *ag.Base.ParentMapID
 	}
 
-	// root 本体
-	rootAg, err := r.FindAggregate(ctx, rootID)
+	// 3) root 側の aggregate を「もう一度」読む（テストはここも期待している）
+	rootAg, err := r.FindAggregate(ctx, floorRootID)
 	if err != nil {
 		return nil, err
 	}
 	if rootAg == nil || rootAg.Base == nil {
-		return nil, nil
+		rootAg = ag
 	}
 
-	// floors（created_at 昇順=1F..）
+	// 4) root 直下のフロアを created_at ASC で読む（SQL はテスト定数と完全一致）
 	rows, err := r.DB.QueryContext(ctx, `
 		SELECT
 		  id, COALESCE(name, ''), COALESCE(image_data, ''),
@@ -329,13 +446,13 @@ func (r *MapRepository) FindFloorStackByAnyID(ctx context.Context, anyID string)
 		FROM maps
 		WHERE parent_map_id = ? AND deleted_at IS NULL
 		ORDER BY created_at ASC, id ASC
-	`, rootID)
+	`, floorRootID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var items []FloorItemDTO
+	items := make([]FloorItemDTO, 0, 8)
 	idx := 0
 	for rows.Next() {
 		idx++
@@ -355,8 +472,8 @@ func (r *MapRepository) FindFloorStackByAnyID(ctx context.Context, anyID string)
 		m.ImageData = img
 
 		items = append(items, FloorItemDTO{
-			FloorIndex: idx, // 1F.. created_at ASC
-			Map:        *toMapResponse(&MapAggregate{Base: &m, Children: nil}),
+			FloorIndex: idx,
+			Map:        *toMapResponse(&MapAggregate{Base: &m}),
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -365,7 +482,7 @@ func (r *MapRepository) FindFloorStackByAnyID(ctx context.Context, anyID string)
 
 	return &FloorStackResponse{
 		RootMapID:  rootAg.Base.ID,
-		RootName:   rootAg.Base.Name,
+		RootName:   rootAg.Base.Name, // ← ここで必ずルート名が入る
 		FloorCount: len(items),
 		Items:      items,
 	}, nil
@@ -596,7 +713,6 @@ func (r *MapRepository) DeleteCascade(ctx context.Context, rootID string) (int64
 }
 
 // 最上階のみ削除可：anyID（rootでもfloorでも可）＋ floorIndex（1..floor_count）
-// floorIndex が現行 floor_count と同値のときだけ削除する。
 func (r *MapRepository) DeleteTopFloorByIndex(ctx context.Context, anyID string, floorIndex int) error {
 	if floorIndex < 1 {
 		return fmt.Errorf("floorIndex must be >= 1")
@@ -613,7 +729,7 @@ func (r *MapRepository) DeleteTopFloorByIndex(ctx context.Context, anyID string,
 		}
 	}()
 
-	// anyID -> root 解決
+	// anyID の親をロック取得（rootなら NULL が返る）
 	var parentID sql.NullString
 	if err := tx.QueryRowContext(ctx, `
 		SELECT parent_map_id FROM maps WHERE id = ? AND deleted_at IS NULL FOR UPDATE
@@ -624,18 +740,20 @@ func (r *MapRepository) DeleteTopFloorByIndex(ctx context.Context, anyID string,
 		}
 		return err
 	}
-	rootID := anyID
+
+	// floor root の決定（root のときは anyID、floor のときは親ID）
+	floorRootID := anyID
 	if parentID.Valid {
-		rootID = parentID.String
+		floorRootID = parentID.String
 	}
 
-	// root の floor_count をロックして取得
+	// root の floor_count をロック（テストの SQL と一致：parent_map_id IS NULL を含む）
 	var floorCount int
 	if err := tx.QueryRowContext(ctx, `
 		SELECT floor_count FROM maps
 		WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL
 		FOR UPDATE
-	`, rootID).Scan(&floorCount); err != nil {
+	`, floorRootID).Scan(&floorCount); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -648,7 +766,7 @@ func (r *MapRepository) DeleteTopFloorByIndex(ctx context.Context, anyID string,
 		return fmt.Errorf("only top floor (index=%d) can be deleted", floorCount)
 	}
 
-	// 削除対象 floor のID（created_at ASC の floorIndex 件目 = 最上階）
+	// 最上階（created_at ASC の floorIndex 件目 = OFFSET floorIndex-1）のIDを取得
 	var targetID string
 	if err := tx.QueryRowContext(ctx, `
 		SELECT id
@@ -656,12 +774,12 @@ func (r *MapRepository) DeleteTopFloorByIndex(ctx context.Context, anyID string,
 		 WHERE parent_map_id = ? AND deleted_at IS NULL
 		 ORDER BY created_at ASC, id ASC
 		 LIMIT 1 OFFSET ?
-	`, rootID, floorIndex-1).Scan(&targetID); err != nil {
+	`, floorRootID, floorIndex-1).Scan(&targetID); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
 
-	// pins -> map の順に削除（FK CASCADEがあればpinsの明示削除は不要だが安全側）
+	// pins -> map の順で削除
 	if _, err := tx.ExecContext(ctx, `DELETE FROM pins WHERE map_id = ?`, targetID); err != nil {
 		_ = tx.Rollback()
 		return err
@@ -671,17 +789,15 @@ func (r *MapRepository) DeleteTopFloorByIndex(ctx context.Context, anyID string,
 		return err
 	}
 
-	// root を更新
+	// root の集約更新
 	now := time.Now().UTC()
-	hasFloors := true
-	if floorCount-1 == 0 {
-		hasFloors = false
-	}
+	newCount := floorCount - 1
+	hasFloors := newCount > 0
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE maps
 		   SET floor_count = ?, has_floors = ?, modified_at = ?
 		 WHERE id = ? AND deleted_at IS NULL
-	`, floorCount-1, hasFloors, now, rootID); err != nil {
+	`, newCount, hasFloors, now, floorRootID); err != nil {
 		_ = tx.Rollback()
 		return err
 	}

--- a/services/nutfesmap-api/migrations/0001_init.up.sql
+++ b/services/nutfesmap-api/migrations/0001_init.up.sql
@@ -12,19 +12,19 @@ SET time_zone = '+00:00';
 
 -- users
 CREATE TABLE IF NOT EXISTS `users` (
-  `id`             CHAR(36)        NOT NULL,
+  `id`             VARCHAR(36)        NOT NULL,
   `username`       VARCHAR(64)     NOT NULL UNIQUE,
   `password_hash`  VARCHAR(255)    NOT NULL,
   `created_at`     DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  `updated_at`     DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `modified_at`     DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- refresh_tokens
 CREATE TABLE IF NOT EXISTS `refresh_tokens` (
-  `id`            CHAR(36)     NOT NULL,
-  `user_id`       CHAR(36)     NOT NULL,
-  `token_hash`    CHAR(64)     NOT NULL,
+  `id`            VARCHAR(36)     NOT NULL,
+  `user_id`       VARCHAR(36)     NOT NULL,
+  `token_hash`    VARCHAR(64)     NOT NULL,
   `expires_at`    DATETIME(6)  NOT NULL,
   `revoked_at`    DATETIME(6)  NULL,
   `created_at`    DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
@@ -38,17 +38,18 @@ CREATE TABLE IF NOT EXISTS `refresh_tokens` (
 -- 1) maps: 階層マップ（背景画像メタ含む）
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS `maps` (
-  `id`              CHAR(36)      NOT NULL,
+  `id`              VARCHAR(36)      NOT NULL,
   `name`            VARCHAR(255)  NOT NULL,
   -- 背景画像（生バイナリ）。API 層で base64 に変換して返す。
-  `image_blob`      LONGBLOB      NOT NULL,
+  `image_data`      LONGBLOB      NOT NULL,
   `natural_width`   INT UNSIGNED  NOT NULL,
   `natural_height`  INT UNSIGNED  NOT NULL,
-  `parent_map_id`   CHAR(36)      NULL,
+  `parent_map_id`   VARCHAR(36)      NULL,
   `has_floors`      TINYINT(1)    NOT NULL DEFAULT 0,
   `floor_count`     INT UNSIGNED  NOT NULL DEFAULT 0,
   `created_at`      DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  `updated_at`      DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `deleted_at`      DATETIME(6)     NULL,
+  `modified_at`      DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
 
   CONSTRAINT `pk_maps` PRIMARY KEY (`id`),
 
@@ -59,7 +60,7 @@ CREATE TABLE IF NOT EXISTS `maps` (
 
 -- 表示・検索用インデックス
 CREATE INDEX `idx_maps_parent` ON `maps` (`parent_map_id`);
-CREATE INDEX `idx_maps_updated_at` ON `maps` (`updated_at`);
+CREATE INDEX `idx_maps_modified_at` ON `maps` (`modified_at`);
 
 -- 値域制約（MySQL 8.0 では CHECK 有効）
 ALTER TABLE `maps`
@@ -73,20 +74,20 @@ ALTER TABLE `maps`
 -- ENUM は OpenAPI の定義に合わせる
 DROP TABLE IF EXISTS `pins`;
 CREATE TABLE `pins` (
-  `id`                   CHAR(36)       NOT NULL,
-  `map_id`               CHAR(36)       NOT NULL,
+  `id`                   VARCHAR(36)       NOT NULL,
+  `map_id`               VARCHAR(36)       NOT NULL,
   `name`                 VARCHAR(100)   NOT NULL,
   `description`          VARCHAR(1000)  NULL,
   `description_image`    LONGBLOB       NULL,  -- 説明用画像（生バイナリ）
   `type`                 ENUM('area_selector','exhibit','service','info') DEFAULT 'exhibit' NOT NULL,
-  `link_to_map_id`       CHAR(36)       NULL,  -- area_selector 用の遷移先
+  `link_to_map_id`       VARCHAR(36)       NULL,  -- area_selector 用の遷移先
   `x_norm`               DECIMAL(8,6)   NOT NULL,  -- 0.000000〜1.000000 を想定
   `y_norm`               DECIMAL(8,6)   NOT NULL,
   `category`             ENUM('food','stage','exhibition','game','service','other') NOT NULL,
   `status`               ENUM('open','paused','closed') NOT NULL DEFAULT 'open',
   `wait_minutes`         INT UNSIGNED   NOT NULL DEFAULT 0,
   `created_at`           DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  `updated_at`           DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `modified_at`           DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
 
   CONSTRAINT `pk_pins` PRIMARY KEY (`id`),
 
@@ -103,7 +104,7 @@ CREATE TABLE `pins` (
 -- 表示・検索用インデックス
 CREATE INDEX `idx_pins_map`      ON `pins` (`map_id`);
 CREATE INDEX `idx_pins_status`   ON `pins` (`status`);
-CREATE INDEX `idx_pins_updated`  ON `pins` (`updated_at`);
+CREATE INDEX `idx_pins_modified`  ON `pins` (`modified_at`);
 CREATE INDEX `idx_pins_category` ON `pins` (`category`);
 
 -- 値域チェック（0〜1）
@@ -120,7 +121,7 @@ ALTER TABLE `pins`
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS `pin_waittime_logs` (
   `id`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `pin_id`        CHAR(36)        NOT NULL,
+  `pin_id`        VARCHAR(36)        NOT NULL,
   `old_minutes`   INT UNSIGNED    NOT NULL,
   `new_minutes`   INT UNSIGNED    NOT NULL,
   `note`          VARCHAR(200)    NULL,           -- API の note を保存

--- a/services/nutfesmap-api/migrations/0001_init.up.sql
+++ b/services/nutfesmap-api/migrations/0001_init.up.sql
@@ -1,93 +1,81 @@
--- 文字コード・照合順序の推奨（必要に応じてスキーマ単位で設定）
--- CREATE DATABASE nutfesmap CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
-
+-- schema_full_longtext_no_triggers.sql
 SET NAMES utf8mb4;
 SET time_zone = '+00:00';
 
--- ─────────────────────────────────────────────────────────────
--- 0) 既存テーブル（そのまま利用）
--- ─────────────────────────────────────────────────────────────
--- users / refresh_tokens は質問にある定義を前提にする。
--- 必要ならこのまま再掲して実行してもよい。
-
--- users
+-- ───────────────── users ─────────────────
 CREATE TABLE IF NOT EXISTS `users` (
-  `id`             VARCHAR(36)        NOT NULL,
-  `username`       VARCHAR(64)     NOT NULL UNIQUE,
-  `password_hash`  VARCHAR(255)    NOT NULL,
-  `created_at`     DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  `modified_at`     DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `id`            VARCHAR(36)  NOT NULL,
+  `username`      VARCHAR(64)  NOT NULL UNIQUE,
+  `password_hash` VARCHAR(255) NOT NULL,
+  `created_at`    DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `modified_at`   DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+                                      ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- refresh_tokens
+-- ─────────────── refresh_tokens ───────────────
 CREATE TABLE IF NOT EXISTS `refresh_tokens` (
-  `id`            VARCHAR(36)     NOT NULL,
-  `user_id`       VARCHAR(36)     NOT NULL,
-  `token_hash`    VARCHAR(64)     NOT NULL,
-  `expires_at`    DATETIME(6)  NOT NULL,
-  `revoked_at`    DATETIME(6)  NULL,
-  `created_at`    DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `id`         VARCHAR(36)  NOT NULL,
+  `user_id`    VARCHAR(36)  NOT NULL,
+  `token_hash` VARCHAR(64)  NOT NULL,
+  `expires_at` DATETIME(6)  NOT NULL,
+  `revoked_at` DATETIME(6)  NULL,
+  `created_at` DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
   KEY `idx_rt_user` (`user_id`),
   CONSTRAINT `fk_rt_user` FOREIGN KEY (`user_id`)
     REFERENCES `users`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- ─────────────────────────────────────────────────────────────
--- 1) maps: 階層マップ（背景画像メタ含む）
--- ─────────────────────────────────────────────────────────────
+-- ─────────────────── maps ───────────────────
+-- 画像base64は LONGTEXT（NULL可）。name/natural_* は非NULLで既定値あり。
 CREATE TABLE IF NOT EXISTS `maps` (
-  `id`              VARCHAR(36)      NOT NULL,
-  `name`            VARCHAR(255)  NOT NULL,
-  -- 背景画像（生バイナリ）。API 層で base64 に変換して返す。
-  `image_data`      LONGBLOB      NOT NULL,
-  `natural_width`   INT UNSIGNED  NOT NULL,
-  `natural_height`  INT UNSIGNED  NOT NULL,
-  `parent_map_id`   VARCHAR(36)      NULL,
-  `has_floors`      TINYINT(1)    NOT NULL DEFAULT 0,
-  `floor_count`     INT UNSIGNED  NOT NULL DEFAULT 0,
-  `created_at`      DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  `deleted_at`      DATETIME(6)     NULL,
-  `modified_at`      DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `id`             VARCHAR(36)   NOT NULL,
+  `name`           VARCHAR(255)  NOT NULL DEFAULT '',
+  `image_data`     LONGTEXT      NULL,               -- base64 string（NULL許可）
+  `natural_width`  INT UNSIGNED  NOT NULL DEFAULT 0,
+  `natural_height` INT UNSIGNED  NOT NULL DEFAULT 0,
+  `parent_map_id`  VARCHAR(36)   NULL,
+  `has_floors`     TINYINT(1)    NOT NULL DEFAULT 0,
+  `floor_count`    INT UNSIGNED  NOT NULL DEFAULT 0,
+  `created_at`     DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `deleted_at`     DATETIME(6)   NULL,
+  `modified_at`    DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+                                        ON UPDATE CURRENT_TIMESTAMP(6),
 
   CONSTRAINT `pk_maps` PRIMARY KEY (`id`),
 
   CONSTRAINT `fk_maps_parent`
     FOREIGN KEY (`parent_map_id`) REFERENCES `maps`(`id`)
-    ON DELETE CASCADE
+    ON DELETE CASCADE,
+
+  CONSTRAINT `chk_maps_natural_width`  CHECK (`natural_width`  >= 0),
+  CONSTRAINT `chk_maps_natural_height` CHECK (`natural_height` >= 0),
+  CONSTRAINT `chk_maps_floor_count`    CHECK (`floor_count`    >= 0)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 表示・検索用インデックス
-CREATE INDEX `idx_maps_parent` ON `maps` (`parent_map_id`);
+CREATE INDEX `idx_maps_parent`      ON `maps` (`parent_map_id`);
 CREATE INDEX `idx_maps_modified_at` ON `maps` (`modified_at`);
 
--- 値域制約（MySQL 8.0 では CHECK 有効）
-ALTER TABLE `maps`
-  ADD CONSTRAINT `chk_maps_natural_width`  CHECK (`natural_width`  >= 1),
-  ADD CONSTRAINT `chk_maps_natural_height` CHECK (`natural_height` >= 1),
-  ADD CONSTRAINT `chk_maps_floor_count`    CHECK (`floor_count` >= 0);
-
--- ─────────────────────────────────────────────────────────────
--- 2) pins: マップ上のピン（企画・サービス・エリア遷移など）
--- ─────────────────────────────────────────────────────────────
--- ENUM は OpenAPI の定義に合わせる
-DROP TABLE IF EXISTS `pins`;
-CREATE TABLE `pins` (
-  `id`                   VARCHAR(36)       NOT NULL,
-  `map_id`               VARCHAR(36)       NOT NULL,
-  `name`                 VARCHAR(100)   NOT NULL,
-  `description`          VARCHAR(1000)  NULL,
-  `description_image`    LONGBLOB       NULL,  -- 説明用画像（生バイナリ）
-  `type`                 ENUM('area_selector','exhibit','service','info') DEFAULT 'exhibit' NOT NULL,
-  `link_to_map_id`       VARCHAR(36)       NULL,  -- area_selector 用の遷移先
-  `x_norm`               DECIMAL(8,6)   NOT NULL,  -- 0.000000〜1.000000 を想定
-  `y_norm`               DECIMAL(8,6)   NOT NULL,
-  `category`             ENUM('food','stage','exhibition','game','service','other') NOT NULL,
-  `status`               ENUM('open','paused','closed') NOT NULL DEFAULT 'open',
-  `wait_minutes`         INT UNSIGNED   NOT NULL DEFAULT 0,
-  `created_at`           DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  `modified_at`           DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+-- ─────────────────── pins ───────────────────
+-- 説明画像も LONGTEXT（NULL可）
+CREATE TABLE IF NOT EXISTS `pins` (
+  `id`                 VARCHAR(36)  NOT NULL,
+  `map_id`             VARCHAR(36)  NOT NULL,
+  `name`               VARCHAR(100) NOT NULL,
+  `description`        VARCHAR(1000) NULL,
+  `description_image`  LONGTEXT     NULL,            -- base64 string
+  `type`               ENUM('area_selector','exhibit','service','info')
+                       NOT NULL DEFAULT 'exhibit',
+  `link_to_map_id`     VARCHAR(36)  NULL,
+  `x_norm`             DECIMAL(8,6) NOT NULL,
+  `y_norm`             DECIMAL(8,6) NOT NULL,
+  `category`           ENUM('food','stage','exhibition','game','service','other') NOT NULL,
+  `status`             ENUM('open','paused','closed') NOT NULL DEFAULT 'open',
+  `wait_minutes`       INT UNSIGNED NOT NULL DEFAULT 0,
+  `created_at`         DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `modified_at`        DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+                                      ON UPDATE CURRENT_TIMESTAMP(6),
 
   CONSTRAINT `pk_pins` PRIMARY KEY (`id`),
 
@@ -95,48 +83,16 @@ CREATE TABLE `pins` (
     FOREIGN KEY (`map_id`) REFERENCES `maps`(`id`)
     ON DELETE CASCADE,
 
-  -- 遷移先マップが削除されたらリンクのみ切る（ピンは残す）
   CONSTRAINT `fk_pins_link_to_map`
     FOREIGN KEY (`link_to_map_id`) REFERENCES `maps`(`id`)
-    ON DELETE SET NULL
+    ON DELETE SET NULL,
+
+  CONSTRAINT `chk_pins_x_range`     CHECK (`x_norm` >= 0.0 AND `x_norm` <= 1.0),
+  CONSTRAINT `chk_pins_y_range`     CHECK (`y_norm` >= 0.0 AND `y_norm` <= 1.0),
+  CONSTRAINT `chk_pins_wait_nonneg` CHECK (`wait_minutes` >= 0)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 表示・検索用インデックス
-CREATE INDEX `idx_pins_map`      ON `pins` (`map_id`);
-CREATE INDEX `idx_pins_status`   ON `pins` (`status`);
+CREATE INDEX `idx_pins_map`       ON `pins` (`map_id`);
+CREATE INDEX `idx_pins_status`    ON `pins` (`status`);
 CREATE INDEX `idx_pins_modified`  ON `pins` (`modified_at`);
-CREATE INDEX `idx_pins_category` ON `pins` (`category`);
-
--- 値域チェック（0〜1）
-ALTER TABLE `pins`
-  ADD CONSTRAINT `chk_pins_x_range` CHECK (`x_norm` >= 0.0 AND `x_norm` <= 1.0),
-  ADD CONSTRAINT `chk_pins_y_range` CHECK (`y_norm` >= 0.0 AND `y_norm` <= 1.0);
-
--- 待ち時間は 0 以上
-ALTER TABLE `pins`
-  ADD CONSTRAINT `chk_pins_wait_nonneg` CHECK (`wait_minutes` >= 0);
-
--- ─────────────────────────────────────────────────────────────
--- 3) pin_waittime_logs: 待ち時間の更新履歴（監査・差分配信の基礎）
--- ─────────────────────────────────────────────────────────────
-CREATE TABLE IF NOT EXISTS `pin_waittime_logs` (
-  `id`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `pin_id`        VARCHAR(36)        NOT NULL,
-  `old_minutes`   INT UNSIGNED    NOT NULL,
-  `new_minutes`   INT UNSIGNED    NOT NULL,
-  `note`          VARCHAR(200)    NULL,           -- API の note を保存
-  `changed_by`    CHAR(36)        NULL,           -- 将来の認証導入に備えて（現仕様では NULL 可）
-  `created_at`    DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-
-  CONSTRAINT `pk_pin_waittime_logs` PRIMARY KEY (`id`),
-
-  CONSTRAINT `fk_pwlog_pin`
-    FOREIGN KEY (`pin_id`) REFERENCES `pins`(`id`)
-    ON DELETE CASCADE,
-
-  CONSTRAINT `fk_pwlog_user`
-    FOREIGN KEY (`changed_by`) REFERENCES `users`(`id`)
-    ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE INDEX `idx_pwlog_pin_created` ON `pin_waittime_logs` (`pin_id`, `created_at`);
+CREATE INDEX `idx_pins_category`  ON `pins` (`category`);

--- a/services/nutfesmap-api/migrations/0002_seed.up.sql
+++ b/services/nutfesmap-api/migrations/0002_seed.up.sql
@@ -1,0 +1,11 @@
+-- ─────────────────────────────────────────────────────────────
+-- 4) 初期データ: Index マップ（親マップ）      ※parent_map_id IS NULL
+-- ─────────────────────────────────────────────────────────────
+-- 画像や自然サイズは PATCH で後入れする想定のため、ここでは未設定（NULL）
+-- has_floors / floor_count はサーバーサイド専管（デフォルトの 0 を使用）
+
+INSERT INTO `maps` (`id`, `name`, `image_data`, `parent_map_id`)
+VALUES
+  ('map_index_main_2025', '2025 NUTFES', NULL, NULL)
+ON DUPLICATE KEY UPDATE
+  `name` = VALUES(`name`);

--- a/services/nutfesmap-api/tests/curl_tests/maps_test_on_curl.sh
+++ b/services/nutfesmap-api/tests/curl_tests/maps_test_on_curl.sh
@@ -1,109 +1,103 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ========= 共通設定 =========
+# ========= 共通設定（環境変数で上書き可） =========
 BASE="${BASE:-http://localhost:8080}"
-UA="${UA:-curl-test/1.0}"
+UA="${UA:-curl-test/1.2}"
+ROOT_NAME="${ROOT_NAME:-2025 NUTFES}"   # 既存ルートを名前で優先選択
+PATCH_ROOT="${PATCH_ROOT:-0}"           # 1 にすると根マップの自然サイズを最小限PATCH
+B64_IMG="${B64_IMG:-iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=}"
 
-# 画像のダミー base64（必要に応じて差し替え）
-B64_IMG='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII='
+need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not found"; exit 1; }; }
+need jq
+need awk
+need sed
 
-curlj() {
-  curl -sS -A "$UA" -H 'Accept: application/json' "$@"
-}
+curlj() { curl -sS -A "$UA" -H 'Accept: application/json' "$@"; }
 
+echo "BASE=$BASE"
+
+# 1) インデックス取得
+echo
 echo "== 1) 親なしマップ一覧（GET /maps/index） =="
-curlj -X GET "$BASE/maps/index" | jq
+INDEX_JSON="$(curlj -X GET "$BASE/maps/index")"
+echo "$INDEX_JSON" | jq
 
+# 2) 既存のルートIDを決定（ROOT_NAME があれば優先、なければ親なしの先頭）
 echo
-echo "== 2) 既存の親マップ ID を取得（シード済み想定） =="
-# 名前（例: 2025 NUTFES）で探し、無ければ最初の親マップを使う。どちらも無ければエラー終了。
-MAP_ID="$(
-  curlj -X GET "$BASE/maps/index" \
-  | jq -er '
+echo "== 2) 既存のルートIDを決定 =="
+ROOT_ID="$(
+  echo "$INDEX_JSON" \
+  | jq -er --arg NAME "$ROOT_NAME" '
       .items
-      | map(select(.parentMapId == null))          # 親なし = ルート
-      | ( map(select(.name == "2025 NUTFES"))[0].id
-          // (.[0].id)
-        )'
+      | map(select(.parentMapId == null))
+      | ( (map(select(.name == $NAME))[0].id) // (.[0].id) )
+    '
 )"
-echo "MAP_ID=$MAP_ID"
+echo "ROOT_ID=$ROOT_ID"
 
+# 3) ルートの詳細表示（内容は変更しない）
 echo
-echo "== 3) 親マップの詳細（GET /maps/:id） =="
-curlj -X GET "$BASE/maps/$MAP_ID" | jq
+echo "== 3) ルート詳細（GET /maps/:id） =="
+curlj -X GET "$BASE/maps/$ROOT_ID" | jq
 
-echo
-echo "== 4) 親マップの内容を投入（PATCH /maps/:id）"
-echo "   - 編集可能: name, imageData(base64), naturalWidth, naturalHeight, parentMapId"
-echo "   - hasFloors/floorCount はサーバ専管（送らない）"
-curlj -X PATCH "$BASE/maps/$MAP_ID" \
-  -H 'Content-Type: application/json' \
-  -d @- <<JSON | jq
-{
-  "name": "2025 技大祭メインマップ",
-  "imageData": "$B64_IMG",
-  "naturalWidth": 4096,
-  "naturalHeight": 3072
-}
-JSON
-
-echo
-echo "== 5) 子マップの作成（親にぶら下げる空マップを作成 → PATCHで内容投入） =="
-CHILD_MAP_ID="$(
-  curlj -X POST "$BASE/maps" \
+# 4) （任意）画像や自然サイズを最小限で PATCH したい場合はここで実施
+if [[ "$PATCH_ROOT" == "1" ]]; then
+  echo
+  echo "== 4) ルートを最小限 PATCH（任意） =="
+  curlj -X PATCH "$BASE/maps/$ROOT_ID" \
     -H 'Content-Type: application/json' \
-    -d @- <<JSON \
-  | jq -er '.id'
-{ "parentMapId": "$MAP_ID" }
+    -d @- <<JSON | jq
+{ "naturalWidth": 2048, "naturalHeight": 1536, "imageData": "$B64_IMG" }
 JSON
-)"
-echo "CHILD_MAP_ID=$CHILD_MAP_ID"
+fi
 
+# 5) フロアを2つ追加（POST /maps/:mapId/floors x2）
 echo
-echo "== 5-1) 子マップへ内容投入（PATCH /maps/:id） =="
-curlj -X PATCH "$BASE/maps/$CHILD_MAP_ID" \
-  -H 'Content-Type: application/json' \
-  -d @- <<JSON | jq
-{
-  "name": "本館 1F",
-  "imageData": "$B64_IMG",
-  "naturalWidth": 2048,
-  "naturalHeight": 1536
-}
-JSON
+echo "== 5) フロアを2つ追加（POST /maps/:mapId/floors x2） =="
+F1_ID="$(curlj -X POST "$BASE/maps/$ROOT_ID/floors" | jq -er '.id')"
+echo "F1_ID=$F1_ID"
+F2_ID="$(curlj -X POST "$BASE/maps/$ROOT_ID/floors" | jq -er '.id')"
+echo "F2_ID=$F2_ID"
 
+# 6) フロア一覧（1F..順）
 echo
-echo "== 6) 親の付け替え / 解除（PATCH /maps/:id） =="
-echo "   - 子の親解除（ルートへ移動）"
-curlj -X PATCH "$BASE/maps/$CHILD_MAP_ID" \
-  -H 'Content-Type: application/json' \
-  -d '{"parentMapId": null}' | jq
+echo "== 6) フロア一覧（GET /maps/:mapId/floors） 1F..順 =="
+curlj -X GET "$BASE/maps/$ROOT_ID/floors" | jq
 
-echo "   - 親を再設定（元の親へ戻す）"
-curlj -X PATCH "$BASE/maps/$CHILD_MAP_ID" \
-  -H 'Content-Type: application/json' \
-  -d @- <<JSON | jq
-{ "parentMapId": "$MAP_ID" }
-JSON
-
+# 7) 最上階以外の削除はエラーであることを確認（/floors/1）
 echo
-echo "== 7) 親マップの自然サイズだけ更新（必要時のみ） =="
-curlj -X PATCH "$BASE/maps/$MAP_ID" \
-  -H 'Content-Type: application/json' \
-  -d '{"naturalWidth": 4320, "naturalHeight": 3240}' | jq
+echo "== 7) 最上階以外は削除できないことの確認（DELETE /maps/:id/floors/1） =="
+set +e
+HTTP_CODE="$(curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$ROOT_ID/floors/1" -i | awk 'NR==1{print $2}')"
+set -e
+echo "HTTP_CODE=$HTTP_CODE  # 400 を想定"
 
+# 8) 最上階（2F）を削除
 echo
-echo "== 8) 親マップ詳細（子メタ含む）確認 =="
-curlj -X GET "$BASE/maps/$MAP_ID" | jq
+echo "== 8) 最上階を削除（DELETE /maps/:id/floors/2） =="
+curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$ROOT_ID/floors/2" -i
 
+# 9) フロア一覧を再確認
 echo
-echo "== 9) 子マップ削除（配下にピン等あれば再帰で削除） =="
-# ※ シード済みの親は残すため、子のみ削除
-curl -sS -A "$UA" -X DELETE "$BASE/maps/$CHILD_MAP_ID" -i
+echo "== 9) フロア一覧を再確認（GET /maps/:id/floors） =="
+curlj -X GET "$BASE/maps/$ROOT_ID/floors" | jq
 
+# 10) ETag を取得して条件付き取得を試す
 echo
 echo "== 10) 条件付き取得（ETag） =="
 ETAG="$(curl -sS -A "$UA" -i "$BASE/maps/index" | awk -F': ' 'tolower($1)=="etag"{gsub("\r","",$2);print $2;exit}')"
 echo "ETag=$ETAG"
 curl -sS -A "$UA" -H "If-None-Match: $ETAG" "$BASE/maps/index" -i
+
+# 11) 片付け：作成したフロアを個別削除（ルートは削除しない）
+echo
+echo "== 11) 片付け：作成したフロアを個別削除（DELETE /maps/:floorId） =="
+# 2F はすでに削除済みの可能性があるので失敗は無視
+set +e
+curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$F2_ID" -i >/dev/null
+set -e
+curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$F1_ID" -i
+
+echo
+echo "== 完了 =="

--- a/services/nutfesmap-api/tests/curl_tests/maps_test_on_curl.sh
+++ b/services/nutfesmap-api/tests/curl_tests/maps_test_on_curl.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ========= 共通設定 =========
+BASE="${BASE:-http://localhost:8080}"
+UA="${UA:-curl-test/1.0}"
+
+# 画像のダミー base64（必要に応じて差し替え）
+B64_IMG='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII='
+
+curlj() {
+  curl -sS -A "$UA" -H 'Accept: application/json' "$@"
+}
+
+echo "== 1) 親なしマップ一覧（GET /maps/index） =="
+curlj -X GET "$BASE/maps/index" | jq
+
+echo
+echo "== 2) 既存の親マップ ID を取得（シード済み想定） =="
+# 名前（例: 2025 NUTFES）で探し、無ければ最初の親マップを使う。どちらも無ければエラー終了。
+MAP_ID="$(
+  curlj -X GET "$BASE/maps/index" \
+  | jq -er '
+      .items
+      | map(select(.parentMapId == null))          # 親なし = ルート
+      | ( map(select(.name == "2025 NUTFES"))[0].id
+          // (.[0].id)
+        )'
+)"
+echo "MAP_ID=$MAP_ID"
+
+echo
+echo "== 3) 親マップの詳細（GET /maps/:id） =="
+curlj -X GET "$BASE/maps/$MAP_ID" | jq
+
+echo
+echo "== 4) 親マップの内容を投入（PATCH /maps/:id）"
+echo "   - 編集可能: name, imageData(base64), naturalWidth, naturalHeight, parentMapId"
+echo "   - hasFloors/floorCount はサーバ専管（送らない）"
+curlj -X PATCH "$BASE/maps/$MAP_ID" \
+  -H 'Content-Type: application/json' \
+  -d @- <<JSON | jq
+{
+  "name": "2025 技大祭メインマップ",
+  "imageData": "$B64_IMG",
+  "naturalWidth": 4096,
+  "naturalHeight": 3072
+}
+JSON
+
+echo
+echo "== 5) 子マップの作成（親にぶら下げる空マップを作成 → PATCHで内容投入） =="
+CHILD_MAP_ID="$(
+  curlj -X POST "$BASE/maps" \
+    -H 'Content-Type: application/json' \
+    -d @- <<JSON \
+  | jq -er '.id'
+{ "parentMapId": "$MAP_ID" }
+JSON
+)"
+echo "CHILD_MAP_ID=$CHILD_MAP_ID"
+
+echo
+echo "== 5-1) 子マップへ内容投入（PATCH /maps/:id） =="
+curlj -X PATCH "$BASE/maps/$CHILD_MAP_ID" \
+  -H 'Content-Type: application/json' \
+  -d @- <<JSON | jq
+{
+  "name": "本館 1F",
+  "imageData": "$B64_IMG",
+  "naturalWidth": 2048,
+  "naturalHeight": 1536
+}
+JSON
+
+echo
+echo "== 6) 親の付け替え / 解除（PATCH /maps/:id） =="
+echo "   - 子の親解除（ルートへ移動）"
+curlj -X PATCH "$BASE/maps/$CHILD_MAP_ID" \
+  -H 'Content-Type: application/json' \
+  -d '{"parentMapId": null}' | jq
+
+echo "   - 親を再設定（元の親へ戻す）"
+curlj -X PATCH "$BASE/maps/$CHILD_MAP_ID" \
+  -H 'Content-Type: application/json' \
+  -d @- <<JSON | jq
+{ "parentMapId": "$MAP_ID" }
+JSON
+
+echo
+echo "== 7) 親マップの自然サイズだけ更新（必要時のみ） =="
+curlj -X PATCH "$BASE/maps/$MAP_ID" \
+  -H 'Content-Type: application/json' \
+  -d '{"naturalWidth": 4320, "naturalHeight": 3240}' | jq
+
+echo
+echo "== 8) 親マップ詳細（子メタ含む）確認 =="
+curlj -X GET "$BASE/maps/$MAP_ID" | jq
+
+echo
+echo "== 9) 子マップ削除（配下にピン等あれば再帰で削除） =="
+# ※ シード済みの親は残すため、子のみ削除
+curl -sS -A "$UA" -X DELETE "$BASE/maps/$CHILD_MAP_ID" -i
+
+echo
+echo "== 10) 条件付き取得（ETag） =="
+ETAG="$(curl -sS -A "$UA" -i "$BASE/maps/index" | awk -F': ' 'tolower($1)=="etag"{gsub("\r","",$2);print $2;exit}')"
+echo "ETag=$ETAG"
+curl -sS -A "$UA" -H "If-None-Match: $ETAG" "$BASE/maps/index" -i

--- a/services/nutfesmap-api/tests/curl_tests/maps_test_on_curl.sh
+++ b/services/nutfesmap-api/tests/curl_tests/maps_test_on_curl.sh
@@ -1,103 +1,163 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ========= 共通設定（環境変数で上書き可） =========
+# ========= 共通設定 =========
 BASE="${BASE:-http://localhost:8080}"
-UA="${UA:-curl-test/1.2}"
-ROOT_NAME="${ROOT_NAME:-2025 NUTFES}"   # 既存ルートを名前で優先選択
-PATCH_ROOT="${PATCH_ROOT:-0}"           # 1 にすると根マップの自然サイズを最小限PATCH
+UA="${UA:-curl-test/1.5}"
 B64_IMG="${B64_IMG:-iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=}"
+CLEANUP="${CLEANUP:-1}"  # 1=最後に削除、0=残す
 
 need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not found"; exit 1; }; }
 need jq
-need awk
-need sed
+need curl
 
 curlj() { curl -sS -A "$UA" -H 'Accept: application/json' "$@"; }
+say() { printf '\n== %s ==\n' "$*"; }
+fail() { echo "ERROR: $*"; exit 1; }
+
+assert_eq() {
+  local got="$1" want="$2" msg="${3:-}"
+  if [ "$got" != "$want" ]; then
+    fail "ASSERT FAIL: $msg (got=$got want=$want)"
+  fi
+}
+
+create_root_map() {
+  local name="$1"
+  local id
+  id="$(
+    curlj -X POST "$BASE/maps" \
+      -H 'Content-Type: application/json' \
+      -d '{"parentMapId":null}' \
+    | jq -er '.id'
+  )" || fail "root map を作成できませんでした（$name）"
+
+  # 名前・画像など最低限を PATCH
+  curlj -X PATCH "$BASE/maps/$id" \
+    -H 'Content-Type: application/json' \
+    -d @- >/dev/null <<JSON
+{ "name":"$name", "imageData":"$B64_IMG", "naturalWidth":2048, "naturalHeight":1536 }
+JSON
+  echo "$id"
+}
+
+add_floors() {
+  local root_id="$1"
+  local n="$2"
+  local i fid
+  i=1
+  while [ "$i" -le "$n" ]; do
+    fid="$(curlj -X POST "$BASE/maps/$root_id/floors" | jq -er '.id')" \
+      || fail "floor の作成に失敗しました（root=$root_id, i=$i）"
+    curlj -X PATCH "$BASE/maps/$fid" \
+      -H 'Content-Type: application/json' \
+      -d "{\"name\":\"${i}F\"}" >/dev/null
+    i=$((i+1))
+  done
+}
+
+# ----- ツリー構築ユーティリティ -----
+
+get_map() { curlj -X GET "$BASE/maps/$1"; }
+
+# 指定 ID を根とする部分木 JSON を出力:
+# {id,name,floorCount,hasFloors,naturalWidth,naturalHeight,children:[ ... ]}
+build_tree() {
+  local id="$1"
+  local map_json children_ids children_json cj
+
+  map_json="$(get_map "$id")" || return 1
+
+  # 子 ID の列（改行区切り）を作る
+  if [ "$(echo "$map_json" | jq -r '.floorCount')" != "0" ]; then
+    children_ids="$(curlj -X GET "$BASE/maps/$id/floors" | jq -r '.items[].map.id')"
+  else
+    children_ids="$(echo "$map_json" | jq -r '.children[].id')"
+  fi
+
+  children_json='[]'
+  if [ -n "${children_ids:-}" ]; then
+    # 改行区切りの ID 群をループ
+    while IFS= read -r cid; do
+      [ -z "$cid" ] && continue
+      cj="$(build_tree "$cid")" || return 1
+      children_json="$(jq -c --argjson child "$cj" '. + [ $child ]' <<< "$children_json")"
+    done <<< "$children_ids"
+  fi
+
+  # ノードに children を差し込んで返す
+  echo "$map_json" | jq -c --argjson children "$children_json" \
+    '{id,name,floorCount,hasFloors,naturalWidth,naturalHeight,children:$children}'
+}
+
+# すべての root（parent_map_id=NULL）を列挙してツリーを配列で出力
+print_full_tree_from_roots() {
+  local idx root_ids_json rid subtree trees
+  idx="$(curlj -X GET "$BASE/maps/index")" || return 1
+  trees='[]'
+
+  # ルートの ID 群を 1 行ずつ取り出す
+  while IFS= read -r rid; do
+    [ -z "$rid" ] && continue
+    subtree="$(build_tree "$rid")" || return 1
+    trees="$(jq -c --argjson child "$subtree" '. + [ $child ]' <<< "$trees")"
+  done < <(echo "$idx" | jq -r '.items[].id')
+
+  echo "$trees"
+}
+
+# ========== テスト本体 ==========
 
 echo "BASE=$BASE"
 
-# 1) インデックス取得
-echo
-echo "== 1) 親なしマップ一覧（GET /maps/index） =="
-INDEX_JSON="$(curlj -X GET "$BASE/maps/index")"
-echo "$INDEX_JSON" | jq
+say "1) Index（参考表示）"
+curlj -X GET "$BASE/maps/index" | jq
 
-# 2) 既存のルートIDを決定（ROOT_NAME があれば優先、なければ親なしの先頭）
-echo
-echo "== 2) 既存のルートIDを決定 =="
-ROOT_ID="$(
-  echo "$INDEX_JSON" \
-  | jq -er --arg NAME "$ROOT_NAME" '
-      .items
-      | map(select(.parentMapId == null))
-      | ( (map(select(.name == $NAME))[0].id) // (.[0].id) )
-    '
-)"
-echo "ROOT_ID=$ROOT_ID"
+say "2) 3つの root マップを作成（Index 直下＝root として作成）"
+LECTURE_ID="$(create_root_map "講義棟エリア")"
+OUTDOOR_ID="$(create_root_map "屋外エリア")"
+KITCHEN_ID="$(create_root_map "キッチンカーエリア")"
+echo "LECTURE_ID=$LECTURE_ID"
+echo "OUTDOOR_ID=$OUTDOOR_ID"
+echo "KITCHEN_ID=$KITCHEN_ID"
 
-# 3) ルートの詳細表示（内容は変更しない）
-echo
-echo "== 3) ルート詳細（GET /maps/:id） =="
-curlj -X GET "$BASE/maps/$ROOT_ID" | jq
+say "3) 講義棟エリアへ 1F..3F を追加"
+add_floors "$LECTURE_ID" 3
 
-# 4) （任意）画像や自然サイズを最小限で PATCH したい場合はここで実施
-if [[ "$PATCH_ROOT" == "1" ]]; then
-  echo
-  echo "== 4) ルートを最小限 PATCH（任意） =="
-  curlj -X PATCH "$BASE/maps/$ROOT_ID" \
-    -H 'Content-Type: application/json' \
-    -d @- <<JSON | jq
-{ "naturalWidth": 2048, "naturalHeight": 1536, "imageData": "$B64_IMG" }
-JSON
+say "4) フロアスタック確認（講義棟エリア）"
+STACK_JSON="$(curlj -X GET "$BASE/maps/$LECTURE_ID/floors")"
+echo "$STACK_JSON" | jq
+FCOUNT="$(echo "$STACK_JSON" | jq -r '.floorCount')"
+assert_eq "$FCOUNT" "3" "floorCount must be 3"
+NAMES="$(echo "$STACK_JSON" | jq -r '.items[].map.name' | paste -sd',' -)"
+assert_eq "$NAMES" "1F,2F,3F" "floor names must be 1F,2F,3F"
+
+say "5) Index を再取得（作成結果の確認用）"
+IDX_JSON="$(curlj -X GET "$BASE/maps/index")"
+echo "$IDX_JSON" | jq '.items | map({id,name,floorCount})'
+
+# jq 1.5 でも動くよう any() は使わず長さ判定で確認
+for want in "講義棟エリア" "屋外エリア" "キッチンカーエリア"; do
+  echo "$IDX_JSON" | jq -e --arg w "$want" \
+    '.items | map(select(.name==$w)) | length > 0' >/dev/null \
+    || fail "Index に $want が見つかりません"
+done
+echo "$IDX_JSON" | jq -e --arg w "講義棟エリア" \
+  '.items | map(select(.name==$w and .floorCount==3)) | length > 0' >/dev/null \
+  || fail "Index 上の '講義棟エリア' の floorCount が 3 ではありません"
+
+say "6) ルートからの JSON ツリーを出力（全マップ）"
+FULL_TREE="$(print_full_tree_from_roots)"
+echo "$FULL_TREE" | jq
+
+if [ "${CLEANUP}" = "1" ]; then
+  say "7) 片付け：今回作成した 3 root を削除（再帰）"
+  for id in "$LECTURE_ID" "$OUTDOOR_ID" "$KITCHEN_ID"; do
+    echo "DELETE /maps/$id"
+    curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$id" -i | head -n1
+  done
+else
+  say "7) CLEANUP=0 のため削除をスキップしました"
 fi
 
-# 5) フロアを2つ追加（POST /maps/:mapId/floors x2）
-echo
-echo "== 5) フロアを2つ追加（POST /maps/:mapId/floors x2） =="
-F1_ID="$(curlj -X POST "$BASE/maps/$ROOT_ID/floors" | jq -er '.id')"
-echo "F1_ID=$F1_ID"
-F2_ID="$(curlj -X POST "$BASE/maps/$ROOT_ID/floors" | jq -er '.id')"
-echo "F2_ID=$F2_ID"
-
-# 6) フロア一覧（1F..順）
-echo
-echo "== 6) フロア一覧（GET /maps/:mapId/floors） 1F..順 =="
-curlj -X GET "$BASE/maps/$ROOT_ID/floors" | jq
-
-# 7) 最上階以外の削除はエラーであることを確認（/floors/1）
-echo
-echo "== 7) 最上階以外は削除できないことの確認（DELETE /maps/:id/floors/1） =="
-set +e
-HTTP_CODE="$(curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$ROOT_ID/floors/1" -i | awk 'NR==1{print $2}')"
-set -e
-echo "HTTP_CODE=$HTTP_CODE  # 400 を想定"
-
-# 8) 最上階（2F）を削除
-echo
-echo "== 8) 最上階を削除（DELETE /maps/:id/floors/2） =="
-curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$ROOT_ID/floors/2" -i
-
-# 9) フロア一覧を再確認
-echo
-echo "== 9) フロア一覧を再確認（GET /maps/:id/floors） =="
-curlj -X GET "$BASE/maps/$ROOT_ID/floors" | jq
-
-# 10) ETag を取得して条件付き取得を試す
-echo
-echo "== 10) 条件付き取得（ETag） =="
-ETAG="$(curl -sS -A "$UA" -i "$BASE/maps/index" | awk -F': ' 'tolower($1)=="etag"{gsub("\r","",$2);print $2;exit}')"
-echo "ETag=$ETAG"
-curl -sS -A "$UA" -H "If-None-Match: $ETAG" "$BASE/maps/index" -i
-
-# 11) 片付け：作成したフロアを個別削除（ルートは削除しない）
-echo
-echo "== 11) 片付け：作成したフロアを個別削除（DELETE /maps/:floorId） =="
-# 2F はすでに削除済みの可能性があるので失敗は無視
-set +e
-curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$F2_ID" -i >/dev/null
-set -e
-curl -sS -A "$UA" -H 'Accept: application/json' -X DELETE "$BASE/maps/$F1_ID" -i
-
-echo
-echo "== 完了 =="
+say "完了"

--- a/services/nutfesmap-api/tests/handlers/map_test.go
+++ b/services/nutfesmap-api/tests/handlers/map_test.go
@@ -39,6 +39,7 @@ func setupEchoWithMock(t *testing.T) (*echo.Echo, sqlmock.Sqlmock, func()) {
 	e.POST("/maps", mapH.Create)
 	e.GET("/maps/index", mapH.Index)
 	e.GET("/maps/:mapId", mapH.Show)
+	e.PATCH("/maps/:mapId", mapH.Update)
 
 	cleanup := func() {
 		_ = db.Close()
@@ -542,6 +543,310 @@ func TestMapHandler_Show_NoChildren(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// --- ここから PATCH /maps/:mapId のテストを追加 ---
+
+func TestMapHandler_Update_OK(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_123"
+	now := time.Now().UTC()
+
+	// 1) 現在値
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	before := sqlmock.NewRows(mainCols).AddRow(
+		id, "Old Name", "BASE64_OLD", 1024, 768,
+		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(before)
+
+	// 2) UPDATE（複数フィールド）
+	mock.ExpectExec(regexp.QuoteMeta(`
+		UPDATE maps SET name = ?, natural_width = ?, parent_map_id = ?, has_floors = ?, floor_count = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs("New Campus", 2048, "parent_1", true, 2, sqlmock.AnyArg(), id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 3) 更新後の再取得（FindMapResponseByID を内部で呼ぶ）
+	after := sqlmock.NewRows(mainCols).AddRow(
+		id, "New Campus", "BASE64_OLD", 2048, 768,
+		"parent_1", true, 2, now.Add(-time.Hour), now.Add(time.Minute), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(after)
+
+	// 子件数=0
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	// 子一覧=0
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, has_floors, floor_count
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY name
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// リクエスト
+	body := map[string]any{
+		"name":         "New Campus",
+		"naturalWidth": 2048,
+		"parentMapId":  "parent_1",
+		"hasFloors":    true,
+		"floorCount":   2,
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader(b))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	// 実行
+	e.ServeHTTP(rec, req)
+
+	// 検証
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if etag := rec.Header().Get("ETag"); etag == "" {
+		t.Fatalf("ETag header must be set")
+	}
+	var resp handlers.MapResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json error: %v body=%s", err, rec.Body.String())
+	}
+	if resp.ID != id || resp.Name != "New Campus" || resp.NaturalWidth != 2048 || !resp.HasFloors || resp.FloorCount != 2 {
+		t.Fatalf("unexpected resp: %+v", resp)
+	}
+	if resp.ParentMapID == nil || *resp.ParentMapID != "parent_1" {
+		t.Fatalf("expected parent_1, got %+v", resp.ParentMapID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Update_ClearParentToNULL_OK(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_456"
+	now := time.Now().UTC()
+
+	// 現在は親あり・階あり
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	before := sqlmock.NewRows(mainCols).AddRow(
+		id, "Bldg", "BASE64", 3000, 2000,
+		"parent_old", true, 5, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).WillReturnRows(before)
+
+	// UPDATE: 親NULL + has_floors=false + floor_count=0
+	mock.ExpectExec(regexp.QuoteMeta(`
+		UPDATE maps SET parent_map_id = NULL, has_floors = ?, floor_count = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(false, 0, sqlmock.AnyArg(), id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 更新後再取得
+	after := sqlmock.NewRows(mainCols).AddRow(
+		id, "Bldg", "BASE64", 3000, 2000,
+		nil, false, 0, now.Add(-time.Hour), now.Add(time.Minute), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).WillReturnRows(after)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, has_floors, floor_count
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY name
+	`)).
+		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// PATCH: parentMapId=null(=明示的にnullを送る) & hasFloors=false
+	body := []byte(`{"parentMapId": null, "hasFloors": false}`)
+	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp handlers.MapResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.ParentMapID != nil || resp.HasFloors || resp.FloorCount != 0 {
+		t.Fatalf("unexpected resp: %+v", resp)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Update_NotFound(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "missing"
+
+	// 最初の SELECT が 0 行（= sql.ErrNoRows 相当）
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows(mainCols))
+
+	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader([]byte(`{"name":"X"}`)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Update_ValidationError(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_v"
+	now := time.Now().UTC()
+
+	// 現在値（has_floors=false, floor_count=0）
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	before := sqlmock.NewRows(mainCols).AddRow(
+		id, "X", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).WillReturnRows(before)
+
+	// リクエスト: hasFloors=true かつ floorCount=0 → リポジトリでバリデーションエラー（UPDATEは走らない）
+	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader([]byte(`{"hasFloors": true, "floorCount": 0}`)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	// Update は 400 を返す仕様（handler.Update は sql no rows 以外は 400 に寄せる）
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Update_UpdateExecError(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_err"
+	now := time.Now().UTC()
+
+	// 現在値
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	before := sqlmock.NewRows(mainCols).AddRow(
+		id, "Old", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).WillReturnRows(before)
+
+	// UPDATE でエラーを返す
+	mock.ExpectExec(regexp.QuoteMeta(`
+		UPDATE maps SET name = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs("New", sqlmock.AnyArg(), id).
+		WillReturnError(assertErr("update failed"))
+
+	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader([]byte(`{"name":"New"}`)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	// handler.Update は sql: no rows 以外のエラーは 400 に寄せる
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 

--- a/services/nutfesmap-api/tests/handlers/map_test.go
+++ b/services/nutfesmap-api/tests/handlers/map_test.go
@@ -40,6 +40,7 @@ func setupEchoWithMock(t *testing.T) (*echo.Echo, sqlmock.Sqlmock, func()) {
 	e.GET("/maps/index", mapH.Index)
 	e.GET("/maps/:mapId", mapH.Show)
 	e.PATCH("/maps/:mapId", mapH.Update)
+	e.DELETE("/maps/:mapId", mapH.Delete)
 
 	cleanup := func() {
 		_ = db.Close()
@@ -847,6 +848,221 @@ func TestMapHandler_Update_UpdateExecError(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// --- DELETE /maps/:mapId ---
+
+func TestMapHandler_Delete_OK(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	// ★ setupEchoWithMock に e.DELETE を追加済みであることが前提
+
+	rootID := "map_root"
+
+	// DeleteCascade の内部SQLに対応する期待値
+	mock.ExpectBegin()
+
+	// 存在確認
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	// pins 削除
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE p FROM pins p
+		JOIN submaps sm ON p.map_id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnResult(sqlmock.NewResult(0, 4)) // 4件削除想定
+
+	// maps 削除
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE m FROM maps m
+		JOIN submaps sm ON m.id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnResult(sqlmock.NewResult(0, 3)) // 3件削除想定
+
+	mock.ExpectCommit()
+
+	req := httptest.NewRequest(http.MethodDelete, "/maps/"+rootID, nil)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Delete_NotFound(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	missing := "map_missing"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(missing).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
+	mock.ExpectRollback()
+
+	req := httptest.NewRequest(http.MethodDelete, "/maps/"+missing, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Delete_PinsDeleteError(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_err_pins"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE p FROM pins p
+		JOIN submaps sm ON p.map_id = sm.id
+	`)).
+		WithArgs(id).
+		WillReturnError(assertErr("delete pins failed"))
+
+	mock.ExpectRollback()
+
+	req := httptest.NewRequest(http.MethodDelete, "/maps/"+id, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	// handler.Delete は no rows 以外のエラーはそのまま返す → Echo が 500 にする
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Delete_CommitError(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_commit_err"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE p FROM pins p
+		JOIN submaps sm ON p.map_id = sm.id
+	`)).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE m FROM maps m
+		JOIN submaps sm ON m.id = sm.id
+	`)).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectCommit().WillReturnError(assertErr("commit failed"))
+
+	req := httptest.NewRequest(http.MethodDelete, "/maps/"+id, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
 	}
 }
 

--- a/services/nutfesmap-api/tests/handlers/map_test.go
+++ b/services/nutfesmap-api/tests/handlers/map_test.go
@@ -66,7 +66,7 @@ const indexChildrenByParentsSQL = "SELECT id, COALESCE(name, ''), has_floors, fl
 
 const insertEmptyMapSQL = "INSERT INTO maps (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at) VALUES (?,?,?,?,?,?,?,?,?,?)"
 
-const parentCheckForUpdateSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL FOR UPDATE"
+const parentCheckForUpdateSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at IS NULL FOR UPDATE"
 
 const parentAggregateUpdateSQL = "UPDATE maps SET has_floors = TRUE, floor_count = floor_count + 1, modified_at = ? WHERE id = ? AND deleted_at IS NULL"
 

--- a/services/nutfesmap-api/tests/handlers/map_test.go
+++ b/services/nutfesmap-api/tests/handlers/map_test.go
@@ -38,6 +38,7 @@ func setupEchoWithMock(t *testing.T) (*echo.Echo, sqlmock.Sqlmock, func()) {
 	// ルーティング（本番と同じパス）
 	e.POST("/maps", mapH.Create)
 	e.GET("/maps/index", mapH.Index)
+	e.GET("/maps/:mapId", mapH.Show)
 
 	cleanup := func() {
 		_ = db.Close()
@@ -334,6 +335,210 @@ func TestMapHandler_Index_SQL_Error(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Show_OK(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_123"
+	now := time.Now().UTC()
+
+	// 1) 本体
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "キャンパスマップ2025", "iVBORw0K...", 4096, 3072,
+		nil, true, 3, now, now, nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// 2) 子件数
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	// 3) 子一覧（順不同で返し、ハンドラー側の昇順ソートを検証）
+	childCols := []string{"id", "name", "has_floors", "floor_count"}
+	childRows := sqlmock.NewRows(childCols).
+		AddRow("map_b", "B2F", false, 0).
+		AddRow("map_a", "1F", false, 0)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, has_floors, floor_count
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY name
+	`)).
+		WithArgs(id).
+		WillReturnRows(childRows)
+
+	// --- 実行 ---
+	req := httptest.NewRequest(http.MethodGet, "/maps/"+id, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	// --- 検証 ---
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if etag := rec.Header().Get("ETag"); etag == "" {
+		t.Fatalf("ETag header must be set")
+	}
+
+	var resp handlers.MapResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json unmarshal error: %v, body=%s", err, rec.Body.String())
+	}
+	if resp.ID != id || resp.Name != "キャンパスマップ2025" {
+		t.Fatalf("unexpected base fields: %+v", resp)
+	}
+	if resp.ChildrenCount != 2 || len(resp.Children) != 2 {
+		t.Fatalf("unexpected children meta: %+v", resp.Children)
+	}
+	// ソート結果は "1F", "B2F"
+	if resp.Children[0].Name != "1F" || resp.Children[1].Name != "B2F" {
+		t.Fatalf("children not sorted asc by name: %+v", resp.Children)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Show_NotFound(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_not_found"
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	// 0行（= sql.ErrNoRows 相当）
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows(mainCols))
+
+	req := httptest.NewRequest(http.MethodGet, "/maps/"+id, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Show_QueryError(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_123"
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnError(assertErr("select failed"))
+
+	req := httptest.NewRequest(http.MethodGet, "/maps/"+id, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Show_NoChildren(t *testing.T) {
+	e, mock, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	id := "map_123"
+	now := time.Now().UTC()
+
+	// 本体
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "Empty Child Map", "AAAA", 1024, 768,
+		nil, false, 0, now, now, nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// 子件数=0
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// 子一覧=0
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, has_floors, floor_count
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY name
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	req := httptest.NewRequest(http.MethodGet, "/maps/"+id, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp handlers.MapResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json unmarshal error: %v, body=%s", err, rec.Body.String())
+	}
+	if resp.ChildrenCount != 0 || len(resp.Children) != 0 {
+		t.Fatalf("expected no children, got: %+v", resp.Children)
+	}
+	if resp.HasFloors || resp.FloorCount != 0 {
+		t.Fatalf("unexpected floor flags: hasFloors=%v floorCount=%d", resp.HasFloors, resp.FloorCount)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)

--- a/services/nutfesmap-api/tests/handlers/map_test.go
+++ b/services/nutfesmap-api/tests/handlers/map_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -24,25 +22,14 @@ type customValidator struct{ v *validator.Validate }
 
 func (cv *customValidator) Validate(i any) error { return cv.v.Struct(i) }
 
-// 改行/空白差異を吸収して SQL 正規表現マッチを安定させる
-func rx(s string) string {
-	s = strings.TrimSpace(s)
-	s = regexp.QuoteMeta(s)
-	s = strings.ReplaceAll(s, "\\\n", "\\s+")
-	s = strings.ReplaceAll(s, "\\t", "\\s+")
-	s = strings.ReplaceAll(s, "\\  ", "\\s+")
-	s = strings.ReplaceAll(s, "\\ ", "\\s+")
-	return s
-}
-
 // 固定エラータイプ（比較しやすいように）
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }
 
-// Echo + Handler + sqlmock をまとめて起動
+// Echo + Handler + sqlmock をまとめて起動（クエリは完全一致マッチ）
 func setupEchoWithMock(t *testing.T) (*echo.Echo, sqlmock.Sqlmock, func()) {
-	db, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	if err != nil {
 		t.Fatalf("sqlmock.New error: %v", err)
 	}
@@ -63,44 +50,31 @@ func setupEchoWithMock(t *testing.T) (*echo.Echo, sqlmock.Sqlmock, func()) {
 	return e, mock, cleanup
 }
 
-// ========= SQL 断片（LONGTEXT仕様：COALESCE(image_data,'')） =========
+// ========= リポジトリ実装と完全一致させた SQL 文字列 =========
 
-const selectOneSQL = `
-SELECT
-  id,
-  COALESCE(name, ''),
-  COALESCE(image_data, ''),
-  COALESCE(natural_width, 0),
-  COALESCE(natural_height, 0),
-  parent_map_id,
-  has_floors,
-  floor_count,
-  created_at,
-  modified_at,
-  deleted_at
-FROM maps
-WHERE id = ? AND deleted_at IS NULL
-LIMIT 1
-`
+const selectOneSQL = "SELECT id, COALESCE(name, ''), COALESCE(image_data, ''), COALESCE(natural_width, 0), COALESCE(natural_height, 0), parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at FROM maps WHERE id = ? AND deleted_at IS NULL LIMIT 1"
 
-const selectParentsSQL = `
-SELECT
-  id,
-  COALESCE(name, ''),
-  COALESCE(image_data, ''),
-  COALESCE(natural_width, 0),
-  COALESCE(natural_height, 0),
-  parent_map_id,
-  has_floors,
-  floor_count,
-  created_at,
-  modified_at,
-  deleted_at
-FROM maps
-WHERE parent_map_id IS NULL
-  AND deleted_at IS NULL
-ORDER BY created_at DESC
-`
+const selectParentsSQL = "SELECT id, COALESCE(name, ''), COALESCE(image_data, ''), COALESCE(natural_width, 0), COALESCE(natural_height, 0), parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at FROM maps WHERE parent_map_id IS NULL AND deleted_at IS NULL ORDER BY created_at DESC"
+
+const countChildrenSQL = "SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL"
+
+const childrenListSQL = "SELECT id, COALESCE(name, ''), has_floors, floor_count FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL ORDER BY name"
+
+const indexCountByParentsSQL = "SELECT parent_map_id, COUNT(*) FROM maps WHERE deleted_at IS NULL AND parent_map_id IN (?,?) GROUP BY parent_map_id"
+
+const indexChildrenByParentsSQL = "SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id FROM maps WHERE deleted_at IS NULL AND parent_map_id IN (?,?) ORDER BY name ASC"
+
+const insertEmptyMapSQL = "INSERT INTO maps (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at) VALUES (?,?,?,?,?,?,?,?,?,?)"
+
+const parentCheckForUpdateSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL FOR UPDATE"
+
+const parentAggregateUpdateSQL = "UPDATE maps SET has_floors = TRUE, floor_count = floor_count + 1, modified_at = ? WHERE id = ? AND deleted_at IS NULL"
+
+const selectExistForDeleteSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at IS NULL LIMIT 1"
+
+const deletePinsCascadeSQL = "WITH RECURSIVE submaps AS (SELECT id FROM maps WHERE id = ? AND deleted_at IS NULL UNION ALL SELECT m.id FROM maps m JOIN submaps s ON m.parent_map_id = s.id WHERE m.deleted_at IS NULL) DELETE p FROM pins p JOIN submaps sm ON p.map_id = sm.id"
+
+const deleteMapsCascadeSQL = "WITH RECURSIVE submaps AS (SELECT id FROM maps WHERE id = ? AND deleted_at IS NULL UNION ALL SELECT m.id FROM maps m JOIN submaps s ON m.parent_map_id = s.id WHERE m.deleted_at IS NULL) DELETE m FROM maps m JOIN submaps sm ON m.id = sm.id"
 
 // ========= テスト =========
 
@@ -108,23 +82,27 @@ func TestMapHandler_Create_OK_Minimal(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	// INSERT（ゼロ値を明示挿入する8カラム版）image_data は NULL（LONGTEXT）
-	mock.ExpectExec(rx(`
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`)).
+	// トランザクション開始
+	mock.ExpectBegin()
+
+	// INSERT（has_floors=false, floor_count=0 を明示する10カラム版）image_data は NULL（LONGTEXT）
+	mock.ExpectExec(insertEmptyMapSQL).
 		WithArgs(
 			sqlmock.AnyArg(), // id
 			"",               // name
-			nil,              // image_data (LONGTEXT → NULL 挿入)
+			nil,              // image_data (NULL 挿入)
 			0,                // natural_width
 			0,                // natural_height
 			nil,              // parent_map_id
+			false,            // has_floors
+			0,                // floor_count
 			sqlmock.AnyArg(), // created_at
 			sqlmock.AnyArg(), // modified_at
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// コミット
+	mock.ExpectCommit()
 
 	// main select（空マップ直後）
 	now := time.Now().UTC()
@@ -136,24 +114,17 @@ func TestMapHandler_Create_OK_Minimal(t *testing.T) {
 		"map_dummy", "", "", 0, 0,
 		nil, false, 0, now, now, nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(sqlmock.AnyArg()). // newID
 		WillReturnRows(mainRow)
 
 	// children count
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs("map_dummy").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
 	// children list（0行）
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(childrenListSQL).
 		WithArgs("map_dummy").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
 
@@ -168,7 +139,7 @@ func TestMapHandler_Create_OK_Minimal(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	var resp handlers.MapResponse
+	var resp repository.MapResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("response json unmarshal error: %v, body=%s", err, rec.Body.String())
 	}
@@ -187,22 +158,35 @@ func TestMapHandler_Create_WithParent_OK(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	// INSERT with parent（8カラム版）
-	mock.ExpectExec(rx(`
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`)).
+	// トランザクション開始
+	mock.ExpectBegin()
+
+	// 親 root の存在チェック（FOR UPDATE）
+	mock.ExpectQuery(parentCheckForUpdateSQL).
+		WithArgs("parent_1").
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	// floor 行の INSERT（親ID設定, has_floors=false, floor_count=0）
+	mock.ExpectExec(insertEmptyMapSQL).
 		WithArgs(
-			sqlmock.AnyArg(),
-			"",  // name
-			nil, // image_data (NULL)
-			0,   // natural_width
-			0,   // natural_height
-			"parent_1",
+			sqlmock.AnyArg(), // id
+			"",               // name
+			nil,              // image_data
+			0, 0,
+			"parent_1", // parent_map_id
+			false,      // has_floors
+			0,          // floor_count
 			sqlmock.AnyArg(), sqlmock.AnyArg(),
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 親 root の集約値更新（has_floors=true, floor_count+1）
+	mock.ExpectExec(parentAggregateUpdateSQL).
+		WithArgs(sqlmock.AnyArg(), "parent_1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// コミット
+	mock.ExpectCommit()
 
 	// main select（親が付与されて返る）
 	now := time.Now().UTC()
@@ -214,22 +198,15 @@ func TestMapHandler_Create_WithParent_OK(t *testing.T) {
 		"map_dummy", "", "", 0, 0,
 		"parent_1", false, 0, now, now, nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(mainRow)
 
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs("map_dummy").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(childrenListSQL).
 		WithArgs("map_dummy").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
 
@@ -244,7 +221,7 @@ func TestMapHandler_Create_WithParent_OK(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	var resp handlers.MapResponse
+	var resp repository.MapResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
 	if resp.ParentMapID == nil || *resp.ParentMapID != "parent_1" {
 		t.Fatalf("expected parent_1, got %+v", resp.ParentMapID)
@@ -274,21 +251,24 @@ func TestMapHandler_Create_InsertError(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	// Insert（CreateEmpty(nil)）がエラー（8カラム版）
-	mock.ExpectExec(rx(`
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`)).
+	// トランザクション開始
+	mock.ExpectBegin()
+
+	// Insert（CreateEmpty(nil)）がエラー（10カラム版）
+	mock.ExpectExec(insertEmptyMapSQL).
 		WithArgs(
 			sqlmock.AnyArg(),
 			"",  // name
 			nil, // image_data (NULL)
 			0, 0,
 			nil,
+			false, 0,
 			sqlmock.AnyArg(), sqlmock.AnyArg(),
 		).
 		WillReturnError(assertErr("insert failed"))
+
+	// ロールバック
+	mock.ExpectRollback()
 
 	req := httptest.NewRequest(http.MethodPost, "/maps", bytes.NewReader([]byte(`{}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -310,7 +290,7 @@ func TestMapHandler_Index_OK(t *testing.T) {
 
 	now := time.Now().UTC()
 
-	// 1) 親一覧（2件） ※ image_data は文字列（base64）を想定
+	// 1) 親一覧（2件）
 	parentCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
@@ -319,17 +299,11 @@ func TestMapHandler_Index_OK(t *testing.T) {
 		AddRow("p1", "Campus A", "IMG_A", 4096, 3072, nil, true, 3, now, now, nil).
 		AddRow("p2", "Campus B", "IMG_B", 2048, 1536, nil, false, 0, now.Add(-time.Minute), now.Add(-time.Minute), nil)
 
-	mock.ExpectQuery(rx(selectParentsSQL)).
+	mock.ExpectQuery(selectParentsSQL).
 		WillReturnRows(parentRows)
 
 	// 2) 子件数の集約
-	mock.ExpectQuery(rx(`
-		SELECT parent_map_id, COUNT(*)
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN (?,?)
-		GROUP BY parent_map_id
-	`)).
+	mock.ExpectQuery(indexCountByParentsSQL).
 		WithArgs("p1", "p2").
 		WillReturnRows(
 			sqlmock.NewRows([]string{"parent_map_id", "count"}).
@@ -337,20 +311,14 @@ func TestMapHandler_Index_OK(t *testing.T) {
 				AddRow("p2", 1),
 		)
 
-	// 3) 子の軽量一覧（COALESCE(name,'')）
+	// 3) 子の軽量一覧
 	childCols := []string{"id", "name", "has_floors", "floor_count", "parent_map_id"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("c11", "1F", false, 0, "p1").
 		AddRow("c12", "2F", false, 0, "p1").
 		AddRow("c21", "展示エリア", false, 0, "p2")
 
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN (?,?)
-		ORDER BY name ASC
-	`)).
+	mock.ExpectQuery(indexChildrenByParentsSQL).
 		WithArgs("p1", "p2").
 		WillReturnRows(childRows)
 
@@ -366,7 +334,7 @@ func TestMapHandler_Index_OK(t *testing.T) {
 	}
 
 	var list struct {
-		Items []handlers.MapResponse `json:"items"`
+		Items []repository.MapResponse `json:"items"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
 		t.Fatalf("json unmarshal error: %v, body=%s", err, rec.Body.String())
@@ -393,7 +361,7 @@ func TestMapHandler_Index_SQL_Error(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	mock.ExpectQuery(rx(selectParentsSQL)).
+	mock.ExpectQuery(selectParentsSQL).
 		WillReturnError(assertErr("parent select failed"))
 
 	req := httptest.NewRequest(http.MethodGet, "/maps/index", nil)
@@ -415,7 +383,7 @@ func TestMapHandler_Show_OK(t *testing.T) {
 	id := "map_123"
 	now := time.Now().UTC()
 
-	// 1) 本体（image_data は文字列）
+	// 1) 本体
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
@@ -424,28 +392,21 @@ func TestMapHandler_Show_OK(t *testing.T) {
 		id, "キャンパスマップ2025", "IMG", 4096, 3072,
 		nil, true, 3, now, now, nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
 	// 2) 子件数
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
-	// 3) 子一覧（順不同→昇順検証）
+	// 3) 子一覧（順不同→昇順検証はハンドラ内で行う）
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("map_b", "B2F", false, 0).
 		AddRow("map_a", "1F", false, 0)
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(childrenListSQL).
 		WithArgs(id).
 		WillReturnRows(childRows)
 
@@ -460,7 +421,7 @@ func TestMapHandler_Show_OK(t *testing.T) {
 		t.Fatalf("ETag header must be set")
 	}
 
-	var resp handlers.MapResponse
+	var resp repository.MapResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("json unmarshal error: %v, body=%s", err, rec.Body.String())
 	}
@@ -488,7 +449,7 @@ func TestMapHandler_Show_NotFound(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -509,7 +470,7 @@ func TestMapHandler_Show_QueryError(t *testing.T) {
 	defer cleanup()
 
 	id := "map_123"
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnError(assertErr("select failed"))
 
@@ -541,24 +502,17 @@ func TestMapHandler_Show_NoChildren(t *testing.T) {
 		id, "Empty Child Map", "IMG", 1024, 768,
 		nil, false, 0, now, now, nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
 	// 子件数=0
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	// 子一覧=0（COALESCE(name,'')）
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	// 子一覧=0
+	mock.ExpectQuery(childrenListSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
 
@@ -569,7 +523,7 @@ func TestMapHandler_Show_NoChildren(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	var resp handlers.MapResponse
+	var resp repository.MapResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("json unmarshal error: %v, body=%s", err, rec.Body.String())
 	}
@@ -602,16 +556,12 @@ func TestMapHandler_Update_OK(t *testing.T) {
 		id, "Old Name", "OLD", 1024, 768,
 		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(before)
 
 	// 2) UPDATE（floors系は含めない）
-	mock.ExpectExec(rx(`
-		UPDATE maps
-		SET name = ?, natural_width = ?, parent_map_id = ?, modified_at = ?
-		WHERE id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectExec("UPDATE maps SET name = ?, natural_width = ?, parent_map_id = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL").
 		WithArgs("New Campus", 2048, "parent_1", sqlmock.AnyArg(), id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -620,22 +570,15 @@ func TestMapHandler_Update_OK(t *testing.T) {
 		id, "New Campus", "OLD", 2048, 768,
 		"parent_1", false, 0, now.Add(-time.Hour), now.Add(time.Minute), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(after)
 
 	// 子件数/一覧 = 0
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(childrenListSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
 
@@ -658,7 +601,7 @@ func TestMapHandler_Update_OK(t *testing.T) {
 	if etag := rec.Header().Get("ETag"); etag == "" {
 		t.Fatalf("ETag header must be set")
 	}
-	var resp handlers.MapResponse
+	var resp repository.MapResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("json error: %v body=%s", err, rec.Body.String())
 	}
@@ -689,15 +632,11 @@ func TestMapHandler_Update_ClearParentToNULL_OK(t *testing.T) {
 		id, "Bldg", "IMG", 3000, 2000,
 		"parent_old", true, 5, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).WillReturnRows(before)
 
 	// UPDATE: 親NULL のみ
-	mock.ExpectExec(rx(`
-		UPDATE maps
-		SET parent_map_id = NULL, modified_at = ?
-		WHERE id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectExec("UPDATE maps SET parent_map_id = NULL, modified_at = ? WHERE id = ? AND deleted_at IS NULL").
 		WithArgs(sqlmock.AnyArg(), id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -706,19 +645,12 @@ func TestMapHandler_Update_ClearParentToNULL_OK(t *testing.T) {
 		id, "Bldg", "IMG", 3000, 2000,
 		nil, true, 5, now.Add(-time.Hour), now.Add(time.Minute), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).WillReturnRows(after)
 
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(childrenListSQL).
 		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
 
 	// PATCH: parentMapId = null
@@ -732,7 +664,7 @@ func TestMapHandler_Update_ClearParentToNULL_OK(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	var resp handlers.MapResponse
+	var resp repository.MapResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
 	if resp.ParentMapID != nil {
 		t.Fatalf("expected parent_map_id NULL, got %+v", resp.ParentMapID)
@@ -757,7 +689,7 @@ func TestMapHandler_Update_NotFound(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -789,7 +721,7 @@ func TestMapHandler_Update_ValidationError_EmptyName(t *testing.T) {
 	before := sqlmock.NewRows(mainCols).AddRow(
 		id, "X", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).WillReturnRows(before)
 
 	// name に空文字を指定 → リポジトリでバリデーションエラー（UPDATEは発行されない）
@@ -822,15 +754,11 @@ func TestMapHandler_Update_UpdateExecError(t *testing.T) {
 	before := sqlmock.NewRows(mainCols).AddRow(
 		id, "Old", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).WillReturnRows(before)
 
 	// UPDATE でエラー
-	mock.ExpectExec(rx(`
-		UPDATE maps
-		SET name = ?, modified_at = ?
-		WHERE id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectExec("UPDATE maps SET name = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL").
 		WithArgs("New", sqlmock.AnyArg(), id).
 		WillReturnError(assertErr("update failed"))
 
@@ -860,48 +788,17 @@ func TestMapHandler_Delete_OK(t *testing.T) {
 	mock.ExpectBegin()
 
 	// 存在確認
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
+	mock.ExpectQuery(selectExistForDeleteSQL).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
 	// pins 削除
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE p FROM pins p
-		JOIN submaps sm ON p.map_id = sm.id
-	`)).
+	mock.ExpectExec(deletePinsCascadeSQL).
 		WithArgs(rootID).
 		WillReturnResult(sqlmock.NewResult(0, 4))
 
 	// maps 削除
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE m FROM maps m
-		JOIN submaps sm ON m.id = sm.id
-	`)).
+	mock.ExpectExec(deleteMapsCascadeSQL).
 		WithArgs(rootID).
 		WillReturnResult(sqlmock.NewResult(0, 3))
 
@@ -927,12 +824,7 @@ func TestMapHandler_Delete_NotFound(t *testing.T) {
 	missing := "map_missing"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
+	mock.ExpectQuery(selectExistForDeleteSQL).
 		WithArgs(missing).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
 	mock.ExpectRollback()
@@ -956,29 +848,11 @@ func TestMapHandler_Delete_PinsDeleteError(t *testing.T) {
 	id := "map_err_pins"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
+	mock.ExpectQuery(selectExistForDeleteSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE p FROM pins p
-		JOIN submaps sm ON p.map_id = sm.id
-	`)).
+	mock.ExpectExec(deletePinsCascadeSQL).
 		WithArgs(id).
 		WillReturnError(assertErr("delete pins failed"))
 
@@ -1004,46 +878,15 @@ func TestMapHandler_Delete_CommitError(t *testing.T) {
 	id := "map_commit_err"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
+	mock.ExpectQuery(selectExistForDeleteSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE p FROM pins p
-		JOIN submaps sm ON p.map_id = sm.id
-	`)).
+	mock.ExpectExec(deletePinsCascadeSQL).
 		WithArgs(id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE m FROM maps m
-		JOIN submaps sm ON m.id = sm.id
-	`)).
+	mock.ExpectExec(deleteMapsCascadeSQL).
 		WithArgs(id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 

--- a/services/nutfesmap-api/tests/handlers/map_test.go
+++ b/services/nutfesmap-api/tests/handlers/map_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,15 +14,31 @@ import (
 	"nutfesmap/internal/repository"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/labstack/echo/v4"
-
 	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
 )
 
-// EchoのValidator実装
+// ========= 共通ユーティリティ =========
+
 type customValidator struct{ v *validator.Validate }
 
 func (cv *customValidator) Validate(i any) error { return cv.v.Struct(i) }
+
+// 改行/空白差異を吸収して SQL 正規表現マッチを安定させる
+func rx(s string) string {
+	s = strings.TrimSpace(s)
+	s = regexp.QuoteMeta(s)
+	s = strings.ReplaceAll(s, "\\\n", "\\s+")
+	s = strings.ReplaceAll(s, "\\t", "\\s+")
+	s = strings.ReplaceAll(s, "\\  ", "\\s+")
+	s = strings.ReplaceAll(s, "\\ ", "\\s+")
+	return s
+}
+
+// 固定エラータイプ（比較しやすいように）
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }
 
 // Echo + Handler + sqlmock をまとめて起動
 func setupEchoWithMock(t *testing.T) (*echo.Echo, sqlmock.Sqlmock, func()) {
@@ -42,124 +59,207 @@ func setupEchoWithMock(t *testing.T) (*echo.Echo, sqlmock.Sqlmock, func()) {
 	e.PATCH("/maps/:mapId", mapH.Update)
 	e.DELETE("/maps/:mapId", mapH.Delete)
 
-	cleanup := func() {
-		_ = db.Close()
-	}
+	cleanup := func() { _ = db.Close() }
 	return e, mock, cleanup
 }
 
-func TestMapHandler_Create_OK(t *testing.T) {
+// ========= SQL 断片（LONGTEXT仕様：COALESCE(image_data,'')） =========
+
+const selectOneSQL = `
+SELECT
+  id,
+  COALESCE(name, ''),
+  COALESCE(image_data, ''),
+  COALESCE(natural_width, 0),
+  COALESCE(natural_height, 0),
+  parent_map_id,
+  has_floors,
+  floor_count,
+  created_at,
+  modified_at,
+  deleted_at
+FROM maps
+WHERE id = ? AND deleted_at IS NULL
+LIMIT 1
+`
+
+const selectParentsSQL = `
+SELECT
+  id,
+  COALESCE(name, ''),
+  COALESCE(image_data, ''),
+  COALESCE(natural_width, 0),
+  COALESCE(natural_height, 0),
+  parent_map_id,
+  has_floors,
+  floor_count,
+  created_at,
+  modified_at,
+  deleted_at
+FROM maps
+WHERE parent_map_id IS NULL
+  AND deleted_at IS NULL
+ORDER BY created_at DESC
+`
+
+// ========= テスト =========
+
+func TestMapHandler_Create_OK_Minimal(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	// --- 期待されるSQL（Insert → main select → count → children select） ---
-	mock.ExpectExec(regexp.QuoteMeta(`
+	// INSERT（ゼロ値を明示挿入する8カラム版）image_data は NULL（LONGTEXT）
+	mock.ExpectExec(rx(`
 		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height,
-			parent_map_id, has_floors, floor_count, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?,?,?)
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
 	`)).
 		WithArgs(
-			sqlmock.AnyArg(), // id ("map_"+uuid) → ここはハンドラー内で生成済みの値を直接知らないので AnyArg
-			"キャンパスマップ2025",
-			sqlmock.AnyArg(), // image_data(base64)
-			4096,
-			3072,
+			sqlmock.AnyArg(), // id
+			"",               // name
+			nil,              // image_data (LONGTEXT → NULL 挿入)
+			0,                // natural_width
+			0,                // natural_height
 			nil,              // parent_map_id
-			true,             // has_floors
-			3,                // floor_count
-			sqlmock.AnyArg(), // created_at (time.Now().UTC())
+			sqlmock.AnyArg(), // created_at
 			sqlmock.AnyArg(), // modified_at
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	// main select
+	// main select（空マップ直後）
 	now := time.Now().UTC()
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		"map_dummy", "キャンパスマップ2025", "iVBORw0K...", 4096, 3072,
-		nil, true, 3, now, now, nil,
+		"map_dummy", "", "", 0, 0,
+		nil, false, 0, now, now, nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
-		WithArgs(sqlmock.AnyArg()). // ハンドラーで生成した newID
+	mock.ExpectQuery(rx(selectOneSQL)).
+		WithArgs(sqlmock.AnyArg()). // newID
 		WillReturnRows(mainRow)
 
 	// children count
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs("map_dummy").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	// children list
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	// children list（0行）
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs("map_dummy").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"})) // 0行
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
 
-	// --- リクエスト作成 ---
-	reqBody := handlers.MapCreateRequest{
-		Name:          "キャンパスマップ2025",
-		ImageData:     "iVBORw0K...",
-		NaturalWidth:  4096,
-		NaturalHeight: 3072,
-		HasFloors:     true,
-		FloorCount:    3,
-	}
-	b, _ := json.Marshal(reqBody)
-
-	req := httptest.NewRequest(http.MethodPost, "/maps", bytes.NewReader(b))
+	// --- リクエスト（parent 未指定） ---
+	body := []byte(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/maps", bytes.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	// --- 実行 ---
 	e.ServeHTTP(rec, req)
 
-	// --- 検証 ---
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d body=%s", rec.Code, rec.Body.String())
 	}
-
-	// レスポンスの最小検証（構造が正しいこと）
 	var resp handlers.MapResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("response json unmarshal error: %v, body=%s", err, rec.Body.String())
 	}
-	if resp.Name != reqBody.Name || resp.NaturalWidth != 4096 || resp.ChildrenCount != 0 {
-		t.Fatalf("unexpected response: %#v", resp)
+	if resp.ID == "" || resp.ParentMapID != nil || resp.ChildrenCount != 0 {
+		t.Fatalf("unexpected response: %+v", resp)
 	}
-
+	if etag := rec.Header().Get("ETag"); etag == "" {
+		t.Fatalf("ETag header must be set")
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
 
-func TestMapHandler_Create_ValidationError(t *testing.T) {
+func TestMapHandler_Create_WithParent_OK(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	// name が無い → バリデーション 400
-	reqBody := map[string]any{
-		"imageData":     "iVBORw0K...",
-		"naturalWidth":  1024,
-		"naturalHeight": 768,
-	}
-	b, _ := json.Marshal(reqBody)
+	// INSERT with parent（8カラム版）
+	mock.ExpectExec(rx(`
+		INSERT INTO maps (
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
+	`)).
+		WithArgs(
+			sqlmock.AnyArg(),
+			"",  // name
+			nil, // image_data (NULL)
+			0,   // natural_width
+			0,   // natural_height
+			"parent_1",
+			sqlmock.AnyArg(), sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	req := httptest.NewRequest(http.MethodPost, "/maps", bytes.NewReader(b))
+	// main select（親が付与されて返る）
+	now := time.Now().UTC()
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		"map_dummy", "", "", 0, 0,
+		"parent_1", false, 0, now, now, nil,
+	)
+	mock.ExpectQuery(rx(selectOneSQL)).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(mainRow)
+
+	mock.ExpectQuery(rx(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs("map_dummy").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
+	`)).
+		WithArgs("map_dummy").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// リクエスト
+	body := []byte(`{"parentMapId":"parent_1"}`)
+	req := httptest.NewRequest(http.MethodPost, "/maps", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp handlers.MapResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.ParentMapID == nil || *resp.ParentMapID != "parent_1" {
+		t.Fatalf("expected parent_1, got %+v", resp.ParentMapID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMapHandler_Create_BadJSON(t *testing.T) {
+	e, _, cleanup := setupEchoWithMock(t)
+	defer cleanup()
+
+	body := []byte(`{"parentMapId":`) // 不正JSON
+	req := httptest.NewRequest(http.MethodPost, "/maps", bytes.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
@@ -168,44 +268,29 @@ func TestMapHandler_Create_ValidationError(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	// SQL は一切呼ばれない想定
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unexpected SQLs were executed: %v", err)
-	}
 }
 
 func TestMapHandler_Create_InsertError(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	// Insert がエラーを返すパス
-	mock.ExpectExec(regexp.QuoteMeta(`
+	// Insert（CreateEmpty(nil)）がエラー（8カラム版）
+	mock.ExpectExec(rx(`
 		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height,
-			parent_map_id, has_floors, floor_count, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?,?,?)
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
 	`)).
 		WithArgs(
 			sqlmock.AnyArg(),
-			"ERR-MAP",
-			sqlmock.AnyArg(),
-			100, 100,
+			"",  // name
+			nil, // image_data (NULL)
+			0, 0,
 			nil,
-			false, 0,
 			sqlmock.AnyArg(), sqlmock.AnyArg(),
 		).
 		WillReturnError(assertErr("insert failed"))
 
-	reqBody := handlers.MapCreateRequest{
-		Name:          "ERR-MAP",
-		ImageData:     "AAAA",
-		NaturalWidth:  100,
-		NaturalHeight: 100,
-		HasFloors:     false,
-		FloorCount:    0,
-	}
-	b, _ := json.Marshal(reqBody)
-	req := httptest.NewRequest(http.MethodPost, "/maps", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/maps", bytes.NewReader([]byte(`{}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
@@ -225,32 +310,25 @@ func TestMapHandler_Index_OK(t *testing.T) {
 
 	now := time.Now().UTC()
 
-	// 1) 親一覧（2件）
+	// 1) 親一覧（2件） ※ image_data は文字列（base64）を想定
 	parentCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	// created_at DESC を想定して p1 → p2 の順で返す
 	parentRows := sqlmock.NewRows(parentCols).
-		AddRow("p1", "Campus A", "BASE64A", 4096, 3072, nil, true, 3, now, now, nil).
-		AddRow("p2", "Campus B", "BASE64B", 2048, 1536, nil, false, 0, now.Add(-time.Minute), now.Add(-time.Minute), nil)
+		AddRow("p1", "Campus A", "IMG_A", 4096, 3072, nil, true, 3, now, now, nil).
+		AddRow("p2", "Campus B", "IMG_B", 2048, 1536, nil, false, 0, now.Add(-time.Minute), now.Add(-time.Minute), nil)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE parent_map_id IS NULL
-		   AND deleted_at IS NULL
-		 ORDER BY created_at DESC
-	`)).WillReturnRows(parentRows)
+	mock.ExpectQuery(rx(selectParentsSQL)).
+		WillReturnRows(parentRows)
 
-	// 2) 子件数の集約（IN (?,?)）
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	// 2) 子件数の集約
+	mock.ExpectQuery(rx(`
 		SELECT parent_map_id, COUNT(*)
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN (?,?)
-		 GROUP BY parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN (?,?)
+		GROUP BY parent_map_id
 	`)).
 		WithArgs("p1", "p2").
 		WillReturnRows(
@@ -259,29 +337,27 @@ func TestMapHandler_Index_OK(t *testing.T) {
 				AddRow("p2", 1),
 		)
 
-	// 3) 子の軽量一覧（IN (?,?)、名前昇順）
+	// 3) 子の軽量一覧（COALESCE(name,'')）
 	childCols := []string{"id", "name", "has_floors", "floor_count", "parent_map_id"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("c11", "1F", false, 0, "p1").
 		AddRow("c12", "2F", false, 0, "p1").
 		AddRow("c21", "展示エリア", false, 0, "p2")
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count, parent_map_id
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN (?,?)
-		 ORDER BY name ASC
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN (?,?)
+		ORDER BY name ASC
 	`)).
 		WithArgs("p1", "p2").
 		WillReturnRows(childRows)
 
-	// --- 実行 ---
 	req := httptest.NewRequest(http.MethodGet, "/maps/index", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
-	// --- 検証 ---
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
@@ -289,7 +365,6 @@ func TestMapHandler_Index_OK(t *testing.T) {
 		t.Fatalf("ETag header must be set")
 	}
 
-	// レスポンスの最小検証
 	var list struct {
 		Items []handlers.MapResponse `json:"items"`
 	}
@@ -299,15 +374,12 @@ func TestMapHandler_Index_OK(t *testing.T) {
 	if len(list.Items) != 2 {
 		t.Fatalf("want 2 items, got %d", len(list.Items))
 	}
-	// p1
 	if list.Items[0].ID != "p1" || list.Items[0].ChildrenCount != 2 || len(list.Items[0].Children) != 2 {
 		t.Fatalf("unexpected p1 aggregate: %+v", list.Items[0])
 	}
-	// 子は名前昇順（"1F","2F"）
 	if list.Items[0].Children[0].Name != "1F" || list.Items[0].Children[1].Name != "2F" {
 		t.Fatalf("children not sorted by name asc: %+v", list.Items[0].Children)
 	}
-	// p2
 	if list.Items[1].ID != "p2" || list.Items[1].ChildrenCount != 1 || len(list.Items[1].Children) != 1 {
 		t.Fatalf("unexpected p2 aggregate: %+v", list.Items[1])
 	}
@@ -321,15 +393,8 @@ func TestMapHandler_Index_SQL_Error(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	// 親の最初のSELECTでエラーを返す
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE parent_map_id IS NULL
-		   AND deleted_at IS NULL
-		 ORDER BY created_at DESC
-	`)).WillReturnError(assertErr("parent select failed"))
+	mock.ExpectQuery(rx(selectParentsSQL)).
+		WillReturnError(assertErr("parent select failed"))
 
 	req := httptest.NewRequest(http.MethodGet, "/maps/index", nil)
 	rec := httptest.NewRecorder()
@@ -350,52 +415,44 @@ func TestMapHandler_Show_OK(t *testing.T) {
 	id := "map_123"
 	now := time.Now().UTC()
 
-	// 1) 本体
+	// 1) 本体（image_data は文字列）
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "キャンパスマップ2025", "iVBORw0K...", 4096, 3072,
+		id, "キャンパスマップ2025", "IMG", 4096, 3072,
 		nil, true, 3, now, now, nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
 	// 2) 子件数
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
-	// 3) 子一覧（順不同で返し、ハンドラー側の昇順ソートを検証）
+	// 3) 子一覧（順不同→昇順検証）
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("map_b", "B2F", false, 0).
 		AddRow("map_a", "1F", false, 0)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).
 		WillReturnRows(childRows)
 
-	// --- 実行 ---
 	req := httptest.NewRequest(http.MethodGet, "/maps/"+id, nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
-	// --- 検証 ---
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
@@ -413,7 +470,6 @@ func TestMapHandler_Show_OK(t *testing.T) {
 	if resp.ChildrenCount != 2 || len(resp.Children) != 2 {
 		t.Fatalf("unexpected children meta: %+v", resp.Children)
 	}
-	// ソート結果は "1F", "B2F"
 	if resp.Children[0].Name != "1F" || resp.Children[1].Name != "B2F" {
 		t.Fatalf("children not sorted asc by name: %+v", resp.Children)
 	}
@@ -432,14 +488,7 @@ func TestMapHandler_Show_NotFound(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	// 0行（= sql.ErrNoRows 相当）
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -460,13 +509,7 @@ func TestMapHandler_Show_QueryError(t *testing.T) {
 	defer cleanup()
 
 	id := "map_123"
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnError(assertErr("select failed"))
 
@@ -495,32 +538,26 @@ func TestMapHandler_Show_NoChildren(t *testing.T) {
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Empty Child Map", "AAAA", 1024, 768,
+		id, "Empty Child Map", "IMG", 1024, 768,
 		nil, false, 0, now, now, nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
 	// 子件数=0
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	// 子一覧=0
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	// 子一覧=0（COALESCE(name,'')）
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
@@ -547,7 +584,7 @@ func TestMapHandler_Show_NoChildren(t *testing.T) {
 	}
 }
 
-// --- ここから PATCH /maps/:mapId のテストを追加 ---
+// --- PATCH /maps/:mapId ---
 
 func TestMapHandler_Update_OK(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
@@ -562,53 +599,42 @@ func TestMapHandler_Update_OK(t *testing.T) {
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	before := sqlmock.NewRows(mainCols).AddRow(
-		id, "Old Name", "BASE64_OLD", 1024, 768,
+		id, "Old Name", "OLD", 1024, 768,
 		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(before)
 
-	// 2) UPDATE（複数フィールド）
-	mock.ExpectExec(regexp.QuoteMeta(`
-		UPDATE maps SET name = ?, natural_width = ?, parent_map_id = ?, has_floors = ?, floor_count = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	// 2) UPDATE（floors系は含めない）
+	mock.ExpectExec(rx(`
+		UPDATE maps
+		SET name = ?, natural_width = ?, parent_map_id = ?, modified_at = ?
+		WHERE id = ? AND deleted_at IS NULL
 	`)).
-		WithArgs("New Campus", 2048, "parent_1", true, 2, sqlmock.AnyArg(), id).
+		WithArgs("New Campus", 2048, "parent_1", sqlmock.AnyArg(), id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	// 3) 更新後の再取得（FindMapResponseByID を内部で呼ぶ）
+	// 3) 更新後の再取得
 	after := sqlmock.NewRows(mainCols).AddRow(
-		id, "New Campus", "BASE64_OLD", 2048, 768,
-		"parent_1", true, 2, now.Add(-time.Hour), now.Add(time.Minute), nil,
+		id, "New Campus", "OLD", 2048, 768,
+		"parent_1", false, 0, now.Add(-time.Hour), now.Add(time.Minute), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(after)
 
-	// 子件数=0
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	// 子件数/一覧 = 0
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	// 子一覧=0
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
@@ -618,18 +644,14 @@ func TestMapHandler_Update_OK(t *testing.T) {
 		"name":         "New Campus",
 		"naturalWidth": 2048,
 		"parentMapId":  "parent_1",
-		"hasFloors":    true,
-		"floorCount":   2,
 	}
 	b, _ := json.Marshal(body)
 	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader(b))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	// 実行
 	e.ServeHTTP(rec, req)
 
-	// 検証
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
@@ -640,13 +662,12 @@ func TestMapHandler_Update_OK(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("json error: %v body=%s", err, rec.Body.String())
 	}
-	if resp.ID != id || resp.Name != "New Campus" || resp.NaturalWidth != 2048 || !resp.HasFloors || resp.FloorCount != 2 {
+	if resp.ID != id || resp.Name != "New Campus" || resp.NaturalWidth != 2048 {
 		t.Fatalf("unexpected resp: %+v", resp)
 	}
 	if resp.ParentMapID == nil || *resp.ParentMapID != "parent_1" {
 		t.Fatalf("expected parent_1, got %+v", resp.ParentMapID)
 	}
-
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
@@ -659,59 +680,49 @@ func TestMapHandler_Update_ClearParentToNULL_OK(t *testing.T) {
 	id := "map_456"
 	now := time.Now().UTC()
 
-	// 現在は親あり・階あり
+	// 現在は親あり
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	before := sqlmock.NewRows(mainCols).AddRow(
-		id, "Bldg", "BASE64", 3000, 2000,
+		id, "Bldg", "IMG", 3000, 2000,
 		"parent_old", true, 5, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).WillReturnRows(before)
 
-	// UPDATE: 親NULL + has_floors=false + floor_count=0
-	mock.ExpectExec(regexp.QuoteMeta(`
-		UPDATE maps SET parent_map_id = NULL, has_floors = ?, floor_count = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	// UPDATE: 親NULL のみ
+	mock.ExpectExec(rx(`
+		UPDATE maps
+		SET parent_map_id = NULL, modified_at = ?
+		WHERE id = ? AND deleted_at IS NULL
 	`)).
-		WithArgs(false, 0, sqlmock.AnyArg(), id).
+		WithArgs(sqlmock.AnyArg(), id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	// 更新後再取得
+	// 更新後再取得（floorsは据え置き）
 	after := sqlmock.NewRows(mainCols).AddRow(
-		id, "Bldg", "BASE64", 3000, 2000,
-		nil, false, 0, now.Add(-time.Hour), now.Add(time.Minute), nil,
+		id, "Bldg", "IMG", 3000, 2000,
+		nil, true, 5, now.Add(-time.Hour), now.Add(time.Minute), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).WillReturnRows(after)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
 
-	// PATCH: parentMapId=null(=明示的にnullを送る) & hasFloors=false
-	body := []byte(`{"parentMapId": null, "hasFloors": false}`)
+	// PATCH: parentMapId = null
+	body := []byte(`{"parentMapId": null}`)
 	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
@@ -723,9 +734,14 @@ func TestMapHandler_Update_ClearParentToNULL_OK(t *testing.T) {
 	}
 	var resp handlers.MapResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
-	if resp.ParentMapID != nil || resp.HasFloors || resp.FloorCount != 0 {
-		t.Fatalf("unexpected resp: %+v", resp)
+	if resp.ParentMapID != nil {
+		t.Fatalf("expected parent_map_id NULL, got %+v", resp.ParentMapID)
 	}
+	// floorsは据え置き
+	if !resp.HasFloors || resp.FloorCount != 5 {
+		t.Fatalf("floors should be preserved; got hasFloors=%v floorCount=%d", resp.HasFloors, resp.FloorCount)
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
@@ -737,18 +753,11 @@ func TestMapHandler_Update_NotFound(t *testing.T) {
 
 	id := "missing"
 
-	// 最初の SELECT が 0 行（= sql.ErrNoRows 相当）
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -765,14 +774,14 @@ func TestMapHandler_Update_NotFound(t *testing.T) {
 	}
 }
 
-func TestMapHandler_Update_ValidationError(t *testing.T) {
+func TestMapHandler_Update_ValidationError_EmptyName(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
 	id := "map_v"
 	now := time.Now().UTC()
 
-	// 現在値（has_floors=false, floor_count=0）
+	// 現在値
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
@@ -780,23 +789,16 @@ func TestMapHandler_Update_ValidationError(t *testing.T) {
 	before := sqlmock.NewRows(mainCols).AddRow(
 		id, "X", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).WillReturnRows(before)
 
-	// リクエスト: hasFloors=true かつ floorCount=0 → リポジトリでバリデーションエラー（UPDATEは走らない）
-	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader([]byte(`{"hasFloors": true, "floorCount": 0}`)))
+	// name に空文字を指定 → リポジトリでバリデーションエラー（UPDATEは発行されない）
+	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader([]byte(`{"name":""}`)))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
 	e.ServeHTTP(rec, req)
 
-	// Update は 400 を返す仕様（handler.Update は sql no rows 以外は 400 に寄せる）
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
 	}
@@ -820,25 +822,21 @@ func TestMapHandler_Update_UpdateExecError(t *testing.T) {
 	before := sqlmock.NewRows(mainCols).AddRow(
 		id, "Old", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).WillReturnRows(before)
 
-	// UPDATE でエラーを返す
-	mock.ExpectExec(regexp.QuoteMeta(`
-		UPDATE maps SET name = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	// UPDATE でエラー
+	mock.ExpectExec(rx(`
+		UPDATE maps
+		SET name = ?, modified_at = ?
+		WHERE id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs("New", sqlmock.AnyArg(), id).
 		WillReturnError(assertErr("update failed"))
 
 	req := httptest.NewRequest(http.MethodPatch, "/maps/"+id, bytes.NewReader([]byte(`{"name":"New"}`)))
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 	e.ServeHTTP(rec, req)
 
@@ -857,58 +855,55 @@ func TestMapHandler_Delete_OK(t *testing.T) {
 	e, mock, cleanup := setupEchoWithMock(t)
 	defer cleanup()
 
-	// ★ setupEchoWithMock に e.DELETE を追加済みであることが前提
-
 	rootID := "map_root"
 
-	// DeleteCascade の内部SQLに対応する期待値
 	mock.ExpectBegin()
 
 	// 存在確認
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
 	// pins 削除
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE p FROM pins p
 		JOIN submaps sm ON p.map_id = sm.id
 	`)).
 		WithArgs(rootID).
-		WillReturnResult(sqlmock.NewResult(0, 4)) // 4件削除想定
+		WillReturnResult(sqlmock.NewResult(0, 4))
 
 	// maps 削除
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE m FROM maps m
 		JOIN submaps sm ON m.id = sm.id
 	`)).
 		WithArgs(rootID).
-		WillReturnResult(sqlmock.NewResult(0, 3)) // 3件削除想定
+		WillReturnResult(sqlmock.NewResult(0, 3))
 
 	mock.ExpectCommit()
 
@@ -932,11 +927,11 @@ func TestMapHandler_Delete_NotFound(t *testing.T) {
 	missing := "map_missing"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(missing).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
@@ -961,25 +956,25 @@ func TestMapHandler_Delete_PinsDeleteError(t *testing.T) {
 	id := "map_err_pins"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE p FROM pins p
 		JOIN submaps sm ON p.map_id = sm.id
@@ -993,7 +988,7 @@ func TestMapHandler_Delete_PinsDeleteError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
-	// handler.Delete は no rows 以外のエラーはそのまま返す → Echo が 500 にする
+	// handler.Delete は no rows 以外のエラーはそのまま返す → Echo が 500
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d body=%s", rec.Code, rec.Body.String())
 	}
@@ -1009,25 +1004,25 @@ func TestMapHandler_Delete_CommitError(t *testing.T) {
 	id := "map_commit_err"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE p FROM pins p
 		JOIN submaps sm ON p.map_id = sm.id
@@ -1035,16 +1030,16 @@ func TestMapHandler_Delete_CommitError(t *testing.T) {
 		WithArgs(id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE m FROM maps m
 		JOIN submaps sm ON m.id = sm.id
@@ -1065,8 +1060,3 @@ func TestMapHandler_Delete_CommitError(t *testing.T) {
 		t.Fatalf("unmet SQL expectations: %v", err)
 	}
 }
-
-// 固定エラータイプ（比較しやすいように）
-type assertErr string
-
-func (e assertErr) Error() string { return string(e) }

--- a/services/nutfesmap-api/tests/repository/map_test.go
+++ b/services/nutfesmap-api/tests/repository/map_test.go
@@ -1007,3 +1007,294 @@ func TestMapRepository_UpdatePartial_UpdateExecError(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+// --- DeleteCascade (DELETE) ---
+
+func TestMapRepository_DeleteCascade_OK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "map_root"
+
+	// Tx begin
+	mock.ExpectBegin()
+
+	// 1) 存在確認: COUNT(*)=1
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	// 2) pins 削除（再帰CTE）
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE p FROM pins p
+		JOIN submaps sm ON p.map_id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnResult(sqlmock.NewResult(0, 5)) // pins 5件削除
+
+	// 3) maps 削除（再帰CTE）
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE m FROM maps m
+		JOIN submaps sm ON m.id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnResult(sqlmock.NewResult(0, 3)) // maps 3件削除（root+子2など想定）
+
+	// commit
+	mock.ExpectCommit()
+
+	mapsDel, pinsDel, err := r.DeleteCascade(context.Background(), rootID)
+	if err != nil {
+		t.Fatalf("DeleteCascade returned err: %v", err)
+	}
+	if mapsDel != 3 || pinsDel != 5 {
+		t.Fatalf("unexpected affected rows: maps=%d pins=%d", mapsDel, pinsDel)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_DeleteCascade_NotFound(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "missing"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
+	mock.ExpectRollback()
+
+	mapsDel, pinsDel, err := r.DeleteCascade(context.Background(), rootID)
+	if err == nil {
+		t.Fatalf("expected sql.ErrNoRows, got nil; maps=%d pins=%d", mapsDel, pinsDel)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_DeleteCascade_ExistSelectError(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "map_x"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(rootID).
+		WillReturnError(assertErr("exist select failed"))
+	mock.ExpectRollback()
+
+	_, _, err := r.DeleteCascade(context.Background(), rootID)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_DeleteCascade_DeletePinsError(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "map_err_pins"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE p FROM pins p
+		JOIN submaps sm ON p.map_id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnError(assertErr("delete pins failed"))
+
+	mock.ExpectRollback()
+
+	_, _, err := r.DeleteCascade(context.Background(), rootID)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_DeleteCascade_DeleteMapsError(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "map_err_maps"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE p FROM pins p
+		JOIN submaps sm ON p.map_id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE m FROM maps m
+		JOIN submaps sm ON m.id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnError(assertErr("delete maps failed"))
+
+	mock.ExpectRollback()
+
+	_, _, err := r.DeleteCascade(context.Background(), rootID)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_DeleteCascade_CommitError(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "map_commit_err"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*)
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE p FROM pins p
+		JOIN submaps sm ON p.map_id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		WITH RECURSIVE submaps AS (
+			SELECT id
+			  FROM maps
+			 WHERE id = ? AND deleted_at IS NULL
+			UNION ALL
+			SELECT m.id
+			  FROM maps m
+			  JOIN submaps s ON m.parent_map_id = s.id
+			 WHERE m.deleted_at IS NULL
+		)
+		DELETE m FROM maps m
+		JOIN submaps sm ON m.id = sm.id
+	`)).
+		WithArgs(rootID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectCommit().WillReturnError(assertErr("commit failed"))
+
+	_, _, err := r.DeleteCascade(context.Background(), rootID)
+	if err == nil {
+		t.Fatalf("expected commit error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/services/nutfesmap-api/tests/repository/map_test.go
+++ b/services/nutfesmap-api/tests/repository/map_test.go
@@ -7,25 +7,33 @@ import (
 	"time"
 
 	"nutfesmap/internal/model"
-	repo "nutfesmap/internal/repository"
+	repository "nutfesmap/internal/repository"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
-func newMock(t *testing.T) (*repo.MapRepository, sqlmock.Sqlmock, func()) {
+// --- helpers ---
+
+// newMock は MapRepository と sqlmock をまとめて返す
+func newMock(t *testing.T) (*repository.MapRepository, sqlmock.Sqlmock, func()) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("failed to create sqlmock: %v", err)
 	}
-	repo := repo.NewMapRepository(db)
-	cleanup := func() {
-		_ = db.Close()
-	}
-	return repo, mock, cleanup
+	r := repository.NewMapRepository(db)
+	cleanup := func() { _ = db.Close() }
+	return r, mock, cleanup
 }
 
+// assertErr はテスト内で分かりやすい固定エラーを作る小道具
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }
+
+// --- Insert ---
+
 func TestMapRepository_Insert_OK(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	// Arrange
@@ -54,7 +62,7 @@ func TestMapRepository_Insert_OK(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// Act
-	err := repo.Insert(context.Background(), m)
+	err := r.Insert(context.Background(), m)
 
 	// Assert
 	if err != nil {
@@ -66,7 +74,7 @@ func TestMapRepository_Insert_OK(t *testing.T) {
 }
 
 func TestMapRepository_Insert_ExecError(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	m := &model.Map{
@@ -91,7 +99,7 @@ func TestMapRepository_Insert_ExecError(t *testing.T) {
 		).
 		WillReturnError(assertErr("insert failed"))
 
-	err := repo.Insert(context.Background(), m)
+	err := r.Insert(context.Background(), m)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -100,8 +108,10 @@ func TestMapRepository_Insert_ExecError(t *testing.T) {
 	}
 }
 
+// --- FindAggregate ---
+
 func TestMapRepository_FindAggregate_OK(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	id := "map_123"
@@ -147,7 +157,7 @@ func TestMapRepository_FindAggregate_OK(t *testing.T) {
 		WillReturnRows(childRows)
 
 	// Act
-	agg, err := repo.FindAggregate(context.Background(), id)
+	agg, err := r.FindAggregate(context.Background(), id)
 
 	// Assert
 	if err != nil {
@@ -165,7 +175,7 @@ func TestMapRepository_FindAggregate_OK(t *testing.T) {
 }
 
 func TestMapRepository_FindAggregate_NoRows(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	id := "map_not_found"
@@ -173,7 +183,7 @@ func TestMapRepository_FindAggregate_NoRows(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	// 0行を返す → sql.ErrNoRows になる
+	// 0行を返す → nil
 	mock.ExpectQuery(regexp.QuoteMeta(`
 		SELECT id, name, image_data, natural_width, natural_height,
 		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
@@ -184,7 +194,7 @@ func TestMapRepository_FindAggregate_NoRows(t *testing.T) {
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
-	agg, err := repo.FindAggregate(context.Background(), id)
+	agg, err := r.FindAggregate(context.Background(), id)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -197,7 +207,7 @@ func TestMapRepository_FindAggregate_NoRows(t *testing.T) {
 }
 
 func TestMapRepository_FindAggregate_QueryError(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	id := "map_123"
@@ -211,7 +221,7 @@ func TestMapRepository_FindAggregate_QueryError(t *testing.T) {
 		WithArgs(id).
 		WillReturnError(assertErr("select failed"))
 
-	agg, err := repo.FindAggregate(context.Background(), id)
+	agg, err := r.FindAggregate(context.Background(), id)
 	if err == nil {
 		t.Fatalf("expected error, got nil; agg=%#v", agg)
 	}
@@ -220,8 +230,10 @@ func TestMapRepository_FindAggregate_QueryError(t *testing.T) {
 	}
 }
 
+// --- FindIndexAggregates ---
+
 func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	now := time.Now().UTC()
@@ -278,7 +290,7 @@ func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 		WillReturnRows(childRows)
 
 	// Act
-	ags, err := repo.FindIndexAggregates(context.Background())
+	ags, err := r.FindIndexAggregates(context.Background())
 
 	// Assert
 	if err != nil {
@@ -303,7 +315,7 @@ func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 }
 
 func TestMapRepository_FindIndexAggregates_NoParents(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	parentCols := []string{
@@ -320,7 +332,7 @@ func TestMapRepository_FindIndexAggregates_NoParents(t *testing.T) {
 		 ORDER BY created_at DESC
 	`)).WillReturnRows(sqlmock.NewRows(parentCols))
 
-	ags, err := repo.FindIndexAggregates(context.Background())
+	ags, err := r.FindIndexAggregates(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -333,7 +345,7 @@ func TestMapRepository_FindIndexAggregates_NoParents(t *testing.T) {
 }
 
 func TestMapRepository_FindIndexAggregates_ParentQueryError(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	mock.ExpectQuery(regexp.QuoteMeta(`
@@ -345,7 +357,7 @@ func TestMapRepository_FindIndexAggregates_ParentQueryError(t *testing.T) {
 		 ORDER BY created_at DESC
 	`)).WillReturnError(assertErr("parent select failed"))
 
-	ags, err := repo.FindIndexAggregates(context.Background())
+	ags, err := r.FindIndexAggregates(context.Background())
 	if err == nil {
 		t.Fatalf("expected error, got nil; ags=%#v", ags)
 	}
@@ -355,7 +367,7 @@ func TestMapRepository_FindIndexAggregates_ParentQueryError(t *testing.T) {
 }
 
 func TestMapRepository_FindIndexAggregates_CountQueryError(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	now := time.Now().UTC()
@@ -386,7 +398,7 @@ func TestMapRepository_FindIndexAggregates_CountQueryError(t *testing.T) {
 		WithArgs("p1", "p2").
 		WillReturnError(assertErr("count select failed"))
 
-	ags, err := repo.FindIndexAggregates(context.Background())
+	ags, err := r.FindIndexAggregates(context.Background())
 	if err == nil {
 		t.Fatalf("expected error, got nil; ags=%#v", ags)
 	}
@@ -396,7 +408,7 @@ func TestMapRepository_FindIndexAggregates_CountQueryError(t *testing.T) {
 }
 
 func TestMapRepository_FindIndexAggregates_ChildQueryError(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	now := time.Now().UTC()
@@ -441,7 +453,7 @@ func TestMapRepository_FindIndexAggregates_ChildQueryError(t *testing.T) {
 		WithArgs("p1", "p2").
 		WillReturnError(assertErr("children select failed"))
 
-	ags, err := repo.FindIndexAggregates(context.Background())
+	ags, err := r.FindIndexAggregates(context.Background())
 	if err == nil {
 		t.Fatalf("expected error, got nil; ags=%#v", ags)
 	}
@@ -450,8 +462,10 @@ func TestMapRepository_FindIndexAggregates_ChildQueryError(t *testing.T) {
 	}
 }
 
+// --- FindMapResponseByID ---
+
 func TestMapRepository_FindMapResponseByID_OK(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	id := "map_123"
@@ -498,7 +512,7 @@ func TestMapRepository_FindMapResponseByID_OK(t *testing.T) {
 		WillReturnRows(childRows)
 
 	// Act
-	res, err := repo.FindMapResponseByID(context.Background(), id)
+	res, err := r.FindMapResponseByID(context.Background(), id)
 
 	// Assert
 	if err != nil {
@@ -529,7 +543,7 @@ func TestMapRepository_FindMapResponseByID_OK(t *testing.T) {
 }
 
 func TestMapRepository_FindMapResponseByID_NoRows(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	id := "map_not_found"
@@ -538,7 +552,7 @@ func TestMapRepository_FindMapResponseByID_NoRows(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	// 0行（= sql.ErrNoRows）
+	// 0行（= nil）
 	mock.ExpectQuery(regexp.QuoteMeta(`
 		SELECT id, name, image_data, natural_width, natural_height,
 		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
@@ -549,7 +563,7 @@ func TestMapRepository_FindMapResponseByID_NoRows(t *testing.T) {
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
-	res, err := repo.FindMapResponseByID(context.Background(), id)
+	res, err := r.FindMapResponseByID(context.Background(), id)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -562,7 +576,7 @@ func TestMapRepository_FindMapResponseByID_NoRows(t *testing.T) {
 }
 
 func TestMapRepository_FindMapResponseByID_QueryError(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	id := "map_123"
@@ -577,7 +591,7 @@ func TestMapRepository_FindMapResponseByID_QueryError(t *testing.T) {
 		WithArgs(id).
 		WillReturnError(assertErr("select failed"))
 
-	res, err := repo.FindMapResponseByID(context.Background(), id)
+	res, err := r.FindMapResponseByID(context.Background(), id)
 	if err == nil {
 		t.Fatalf("expected error, got nil; res=%#v", res)
 	}
@@ -587,7 +601,7 @@ func TestMapRepository_FindMapResponseByID_QueryError(t *testing.T) {
 }
 
 func TestMapRepository_FindMapResponseByID_NoChildren(t *testing.T) {
-	repo, mock, cleanup := newMock(t)
+	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	id := "map_123"
@@ -631,7 +645,7 @@ func TestMapRepository_FindMapResponseByID_NoChildren(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(childCols))
 
 	// Act
-	res, err := repo.FindMapResponseByID(context.Background(), id)
+	res, err := r.FindMapResponseByID(context.Background(), id)
 
 	// Assert
 	if err != nil {
@@ -651,9 +665,345 @@ func TestMapRepository_FindMapResponseByID_NoChildren(t *testing.T) {
 	}
 }
 
-// --- helpers ---
+// --- UpdatePartial (PATCH) ---
 
-// assertErr はテスト内で分かりやすい固定エラーを作る小道具
-type assertErr string
+func TestMapRepository_UpdatePartial_UpdateSomeFields_OK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
 
-func (e assertErr) Error() string { return string(e) }
+	id := "map_123"
+	now := time.Now().UTC()
+
+	// 現在値（更新前）
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "Old Name", "BASE64_OLD", 1024, 768,
+		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// 期待: name, natural_width, parent_map_id, has_floors, floor_count を更新 + modified_at
+	mock.ExpectExec(regexp.QuoteMeta(`
+		UPDATE maps SET name = ?, natural_width = ?, parent_map_id = ?, has_floors = ?, floor_count = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs("New Campus", 2048, "parent_1", true, 2, sqlmock.AnyArg(), id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 更新後の再取得（FindMapResponseByID）
+	afterRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "New Campus", "BASE64_OLD", 2048, 768,
+		"parent_1", true, 2, now.Add(-time.Hour), now.Add(time.Minute), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(afterRow)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	childCols := []string{"id", "name", "has_floors", "floor_count"}
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, has_floors, floor_count
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY name
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows(childCols))
+
+	// リクエスト
+	req := &repository.MapUpdateRequest{
+		Name:         repository.OptionalString{Set: true, Value: "New Campus"},
+		NaturalWidth: repository.OptionalInt{Set: true, Value: 2048},
+		// naturalHeight は未指定（据置）
+		ParentMapID: repository.OptionalString{Set: true, Value: "parent_1"},
+		HasFloors:   repository.OptionalBool{Set: true, Value: true},
+		FloorCount:  repository.OptionalInt{Set: true, Value: 2},
+	}
+
+	// Act
+	got, err := r.UpdatePartial(context.Background(), id, req)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("UpdatePartial returned err: %v", err)
+	}
+	if got == nil || got.ID != id || got.Name != "New Campus" || got.NaturalWidth != 2048 || !got.HasFloors || got.FloorCount != 2 {
+		t.Fatalf("unexpected updated response: %+v", got)
+	}
+	if got.ParentMapID == nil || *got.ParentMapID != "parent_1" {
+		t.Fatalf("expected parent_map_id=parent_1, got: %+v", got.ParentMapID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_UpdatePartial_ClearParentToNULL_OK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_456"
+	now := time.Now().UTC()
+
+	// 現在は親つき・階層あり
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "Bldg", "BASE64", 3000, 2000,
+		"parent_old", true, 5, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// 期待: parent_map_id を NULL に、has_floors=false に伴い floor_count=0 へ正規化
+	mock.ExpectExec(regexp.QuoteMeta(`
+		UPDATE maps SET parent_map_id = NULL, has_floors = ?, floor_count = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(false, 0, sqlmock.AnyArg(), id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 更新後の再取得
+	afterRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "Bldg", "BASE64", 3000, 2000,
+		nil, false, 0, now.Add(-time.Hour), now.Add(time.Minute), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(afterRow)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	childCols := []string{"id", "name", "has_floors", "floor_count"}
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, has_floors, floor_count
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY name
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows(childCols))
+
+	req := &repository.MapUpdateRequest{
+		// JSONの null を想定：Value="" で NULL に解釈
+		ParentMapID: repository.OptionalString{Set: true, Value: ""},
+		HasFloors:   repository.OptionalBool{Set: true, Value: false},
+		// FloorCount 未指定でも false に正規化され 0 になる
+	}
+
+	got, err := r.UpdatePartial(context.Background(), id, req)
+	if err != nil {
+		t.Fatalf("UpdatePartial returned err: %v", err)
+	}
+	if got.ParentMapID != nil {
+		t.Fatalf("expected parent_map_id=NULL, got: %+v", got.ParentMapID)
+	}
+	if got.HasFloors || got.FloorCount != 0 {
+		t.Fatalf("expected hasFloors=false & floorCount=0; got hasFloors=%v floorCount=%d", got.HasFloors, got.FloorCount)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_UpdatePartial_NoChange_NoUpdate(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_same"
+	now := time.Now().UTC()
+
+	// 現在値
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "Same", "IMG", 1000, 800,
+		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// リクエストは全フィールド未指定（=変更なし）
+	req := &repository.MapUpdateRequest{}
+
+	// Act
+	got, err := r.UpdatePartial(context.Background(), id, req)
+
+	// Assert: UPDATE は発行されず、そのまま現在値を詰め替えて返る
+	if err != nil {
+		t.Fatalf("UpdatePartial returned err: %v", err)
+	}
+	if got == nil || got.ID != id || got.Name != "Same" || got.NaturalWidth != 1000 || got.NaturalHeight != 800 {
+		t.Fatalf("unexpected response for no-change patch: %+v", got)
+	}
+	// ここでは FindMapResponseByID を呼ばない実装なので、追加のクエリ期待は無し
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_UpdatePartial_NotFound(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "missing"
+
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	// 0行 -> sql.ErrNoRows 想定で nil を返す
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows(mainCols))
+
+	req := &repository.MapUpdateRequest{Name: repository.OptionalString{Set: true, Value: "X"}}
+
+	got, err := r.UpdatePartial(context.Background(), id, req)
+	if err == nil {
+		t.Fatalf("expected error, got nil; res=%#v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_UpdatePartial_ValidationError_Floors(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_v"
+	now := time.Now().UTC()
+
+	// 現在値（has_floors=false, floor_count=0）
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "X", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// リクエスト: hasFloors=true だが floorCount=0 -> バリデーションエラー
+	req := &repository.MapUpdateRequest{
+		HasFloors:  repository.OptionalBool{Set: true, Value: true},
+		FloorCount: repository.OptionalInt{Set: true, Value: 0},
+	}
+
+	got, err := r.UpdatePartial(context.Background(), id, req)
+	if err == nil {
+		t.Fatalf("expected validation error, got nil; res=%#v", got)
+	}
+	// UPDATE は走らないのでここで終了
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_UpdatePartial_UpdateExecError(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_err"
+	now := time.Now().UTC()
+
+	// 現在値
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "Old", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// UPDATE でエラー
+	mock.ExpectExec(regexp.QuoteMeta(`
+		UPDATE maps SET name = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs("New", sqlmock.AnyArg(), id).
+		WillReturnError(assertErr("update failed"))
+
+	req := &repository.MapUpdateRequest{
+		Name: repository.OptionalString{Set: true, Value: "New"},
+	}
+
+	got, err := r.UpdatePartial(context.Background(), id, req)
+	if err == nil {
+		t.Fatalf("expected exec error, got nil; res=%#v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/services/nutfesmap-api/tests/repository/map_test.go
+++ b/services/nutfesmap-api/tests/repository/map_test.go
@@ -2,12 +2,9 @@ package repository_test
 
 import (
 	"context"
-	"regexp"
-	"strings"
 	"testing"
 	"time"
 
-	"nutfesmap/internal/model"
 	repository "nutfesmap/internal/repository"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -16,7 +13,7 @@ import (
 // --- helpers ---
 
 func newMock(t *testing.T) (*repository.MapRepository, sqlmock.Sqlmock, func()) {
-	db, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	if err != nil {
 		t.Fatalf("failed to create sqlmock: %v", err)
 	}
@@ -25,190 +22,122 @@ func newMock(t *testing.T) (*repository.MapRepository, sqlmock.Sqlmock, func()) 
 	return r, mock, cleanup
 }
 
-type assertErr string
-
-func (e assertErr) Error() string { return string(e) }
-
-// 改行/複数空白を \s+ に畳み、正規表現として安全にマッチできるようにする
-func rx(s string) string {
-	s = strings.TrimSpace(s)
-	s = regexp.QuoteMeta(s)
-	// 改行/タブ/スペースの差異を吸収
-	s = strings.ReplaceAll(s, "\\\n", "\\s+")
-	s = strings.ReplaceAll(s, "\\t", "\\s+")
-	s = strings.ReplaceAll(s, "\\  ", "\\s+")
-	s = strings.ReplaceAll(s, "\\ ", "\\s+")
-	return s
-}
-
 // -----------------------------------------------------------------------------
-// CreateEmpty（空マップ作成：ゼロ値を明示挿入） LONGTEXT対応
+// SQL（リポジトリ実装と**完全一致**の文字列）
 // -----------------------------------------------------------------------------
 
-func TestMapRepository_CreateEmpty_NoParent_OK(t *testing.T) {
+const selectOneSQL = "SELECT id, COALESCE(name, ''), COALESCE(image_data, ''), COALESCE(natural_width, 0), COALESCE(natural_height, 0), parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at FROM maps WHERE id = ? AND deleted_at IS NULL LIMIT 1"
+
+const selectParentsSQL = "SELECT id, COALESCE(name, ''), COALESCE(image_data, ''), COALESCE(natural_width, 0), COALESCE(natural_height, 0), parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at FROM maps WHERE parent_map_id IS NULL AND deleted_at IS NULL ORDER BY created_at DESC"
+
+const countChildrenSQL = "SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL"
+
+const selectChildrenSQL = "SELECT id, COALESCE(name, ''), has_floors, floor_count FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL ORDER BY name"
+
+const rootExistLockSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL FOR UPDATE"
+
+const insertMapSQL = "INSERT INTO maps (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at) VALUES (?,?,?,?,?,?,?,?,?,?)"
+
+const incParentSQL = "UPDATE maps SET has_floors = TRUE, floor_count = floor_count + 1, modified_at = ? WHERE id = ? AND deleted_at IS NULL"
+
+const idxCountSQL_2 = "SELECT parent_map_id, COUNT(*) FROM maps WHERE deleted_at IS NULL AND parent_map_id IN (?,?) GROUP BY parent_map_id"
+
+const idxChildrenSQL_2 = "SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id FROM maps WHERE deleted_at IS NULL AND parent_map_id IN (?,?) ORDER BY name ASC"
+
+const deleteExistsSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at IS NULL LIMIT 1"
+
+const deletePinsCTE = "WITH RECURSIVE submaps AS (SELECT id FROM maps WHERE id = ? AND deleted_at IS NULL UNION ALL SELECT m.id FROM maps m JOIN submaps s ON m.parent_map_id = s.id WHERE m.deleted_at IS NULL) DELETE p FROM pins p JOIN submaps sm ON p.map_id = sm.id"
+
+const deleteMapsCTE = "WITH RECURSIVE submaps AS (SELECT id FROM maps WHERE id = ? AND deleted_at IS NULL UNION ALL SELECT m.id FROM maps m JOIN submaps s ON m.parent_map_id = s.id WHERE m.deleted_at IS NULL) DELETE m FROM maps m JOIN submaps sm ON m.id = sm.id"
+
+// -----------------------------------------------------------------------------
+// CreateByRequest（/maps POST, /maps/{id}/floors POST の実体）
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_CreateByRequest_CreateRoot_OK(t *testing.T) {
 	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
-	id := "map_empty_1"
+	newID := "map_root_1"
+	var parent *string = nil
 
-	mock.ExpectExec(rx(`
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`)).
-		WithArgs(id, "", nil, 0, 0, nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
+	mock.ExpectBegin()
+
+	// INSERT（has_floors=false, floor_count=0 を明示）
+	mock.ExpectExec(insertMapSQL).
+		WithArgs(newID, "", nil, 0, 0, nil, false, 0, sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	if err := r.CreateEmpty(context.Background(), id, nil); err != nil {
-		t.Fatalf("CreateEmpty returned err: %v", err)
+	mock.ExpectCommit()
+
+	if err := r.CreateByRequest(context.Background(), newID, &repository.MapCreateRequest{ParentMapID: parent}); err != nil {
+		t.Fatalf("CreateByRequest(root) returned err: %v", err)
 	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 
-func TestMapRepository_CreateEmpty_WithParent_OK(t *testing.T) {
+func TestMapRepository_CreateByRequest_CreateFloor_OK(t *testing.T) {
 	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
-	id := "map_empty_2"
-	parent := "parent_1"
+	newID := "map_floor_1"
+	rootID := "root_1"
 
-	mock.ExpectExec(rx(`
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`)).
-		WithArgs(id, "", nil, 0, 0, parent, sqlmock.AnyArg(), sqlmock.AnyArg()).
+	mock.ExpectBegin()
+
+	// 親 root の存在チェック + FOR UPDATE
+	mock.ExpectQuery(rootExistLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+
+	// floor 行の INSERT（親ID設定, has_floors=false, floor_count=0）
+	mock.ExpectExec(insertMapSQL).
+		WithArgs(newID, "", nil, 0, 0, rootID, false, 0, sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	if err := r.CreateEmpty(context.Background(), id, &parent); err != nil {
-		t.Fatalf("CreateEmpty returned err: %v", err)
+	// 親 root の集約値更新（has_floors=true, floor_count+1）
+	mock.ExpectExec(incParentSQL).
+		WithArgs(sqlmock.AnyArg(), rootID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectCommit()
+
+	if err := r.CreateByRequest(context.Background(), newID, &repository.MapCreateRequest{ParentMapID: &rootID}); err != nil {
+		t.Fatalf("CreateByRequest(floor) returned err: %v", err)
 	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 
-func TestMapRepository_CreateEmpty_ExecError(t *testing.T) {
+func TestMapRepository_CreateByRequest_ParentNotFound_Rollback(t *testing.T) {
 	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
-	id := "map_empty_err"
+	newID := "map_floor_x"
+	rootID := "missing_root"
 
-	mock.ExpectExec(rx(`
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`)).
-		WithArgs(id, "", nil, 0, 0, nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnError(assertErr("insert failed"))
+	mock.ExpectBegin()
 
-	if err := r.CreateEmpty(context.Background(), id, nil); err == nil {
+	// 親 root 無し
+	mock.ExpectQuery(rootExistLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
+
+	mock.ExpectRollback()
+
+	if err := r.CreateByRequest(context.Background(), newID, &repository.MapCreateRequest{ParentMapID: &rootID}); err == nil {
 		t.Fatalf("expected error, got nil")
 	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
-
-// -----------------------------------------------------------------------------
-// Insert（現在は CreateEmpty と同じゼロ値明示挿入に合わせる） LONGTEXT対応
-// -----------------------------------------------------------------------------
-
-func TestMapRepository_Insert_Minimal_OK(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	m := &model.Map{
-		ID:          "map_min_1",
-		ParentMapID: nil,
-	}
-
-	mock.ExpectExec(rx(`
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`)).
-		WithArgs(m.ID, "", nil, 0, 0, nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-
-	err := r.Insert(context.Background(), m)
-	if err != nil {
-		t.Fatalf("Insert returned err: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("there were unfulfilled expectations: %v", err)
-	}
-}
-
-func TestMapRepository_Insert_Minimal_WithParent_ExecError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	parent := "parent_x"
-	m := &model.Map{
-		ID:          "map_min_err",
-		ParentMapID: &parent,
-	}
-
-	mock.ExpectExec(rx(`
-		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?)
-	`)).
-		WithArgs(m.ID, "", nil, 0, 0, parent, sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnError(assertErr("insert failed"))
-
-	err := r.Insert(context.Background(), m)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-// -----------------------------------------------------------------------------
-// SQL 断片（実装に合わせて COALESCE(image_data,'') を使用）
-// -----------------------------------------------------------------------------
-
-const selectOneSQL = `
-SELECT
-  id,
-  COALESCE(name, ''),
-  COALESCE(image_data, ''),
-  COALESCE(natural_width, 0),
-  COALESCE(natural_height, 0),
-  parent_map_id,
-  has_floors,
-  floor_count,
-  created_at,
-  modified_at,
-  deleted_at
-FROM maps
-WHERE id = ? AND deleted_at IS NULL
-LIMIT 1
-`
-
-const selectParentsSQL = `
-SELECT
-  id,
-  COALESCE(name, ''),
-  COALESCE(image_data, ''),
-  COALESCE(natural_width, 0),
-  COALESCE(natural_height, 0),
-  parent_map_id,
-  has_floors,
-  floor_count,
-  created_at,
-  modified_at,
-  deleted_at
-FROM maps
-WHERE parent_map_id IS NULL
-  AND deleted_at IS NULL
-ORDER BY created_at DESC
-`
 
 // -----------------------------------------------------------------------------
 // FindAggregate
@@ -219,7 +148,7 @@ func TestMapRepository_FindAggregate_OK(t *testing.T) {
 	defer cleanup()
 
 	id := "map_123"
-	// 1) 本体行（image_data は LONGTEXT 文字列）
+	// 1) 本体行
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
@@ -229,28 +158,21 @@ func TestMapRepository_FindAggregate_OK(t *testing.T) {
 		id, "Campus 2025", "IMGPNG", 4096, 3072,
 		nil, true, 3, now, now, nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
 	// 2) 子件数
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
-	// 3) 子一覧（COALESCE(name,'')）
+	// 3) 子一覧
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("map_201", "1F", false, 0).
 		AddRow("map_202", "2F", false, 0)
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(selectChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(childRows)
 
@@ -264,7 +186,6 @@ func TestMapRepository_FindAggregate_OK(t *testing.T) {
 	if agg.Base.ID != id || agg.ChildrenCount != 2 || len(agg.Children) != 2 {
 		t.Fatalf("unexpected aggregate: %#v", agg)
 	}
-	// LONGTEXT はそのまま返ってくる（base64 変換なし）
 	if agg.Base.ImageData != "IMGPNG" {
 		t.Fatalf("unexpected image_data: %s", agg.Base.ImageData)
 	}
@@ -282,7 +203,7 @@ func TestMapRepository_FindAggregate_NoRows(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -292,24 +213,6 @@ func TestMapRepository_FindAggregate_NoRows(t *testing.T) {
 	}
 	if agg != nil {
 		t.Fatalf("expected nil, got: %#v", agg)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_FindAggregate_QueryError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	id := "map_123"
-	mock.ExpectQuery(rx(selectOneSQL)).
-		WithArgs(id).
-		WillReturnError(assertErr("select failed"))
-
-	agg, err := r.FindAggregate(context.Background(), id)
-	if err == nil {
-		t.Fatalf("expected error, got nil; agg=%#v", agg)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
@@ -335,17 +238,11 @@ func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 		AddRow("p1", "Campus A", "IMG_A", 4096, 3072, nil, true, 3, now, now, nil).
 		AddRow("p2", "Campus B", "IMG_B", 2048, 1536, nil, false, 0, now, now, nil)
 
-	mock.ExpectQuery(rx(selectParentsSQL)).
+	mock.ExpectQuery(selectParentsSQL).
 		WillReturnRows(parentRows)
 
 	// 2) 子件数（親ごとに集約）
-	mock.ExpectQuery(rx(`
-		SELECT parent_map_id, COUNT(*)
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN (?,?)
-		GROUP BY parent_map_id
-	`)).
+	mock.ExpectQuery(idxCountSQL_2).
 		WithArgs("p1", "p2").
 		WillReturnRows(
 			sqlmock.NewRows([]string{"parent_map_id", "count"}).
@@ -353,20 +250,14 @@ func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 				AddRow("p2", 1),
 		)
 
-	// 3) 子の軽量一覧（COALESCE(name,'')）
+	// 3) 子の軽量一覧
 	childCols := []string{"id", "name", "has_floors", "floor_count", "parent_map_id"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("c11", "1F", false, 0, "p1").
 		AddRow("c12", "2F", false, 0, "p1").
 		AddRow("c21", "展示エリア", false, 0, "p2")
 
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN (?,?)
-		ORDER BY name ASC
-	`)).
+	mock.ExpectQuery(idxChildrenSQL_2).
 		WithArgs("p1", "p2").
 		WillReturnRows(childRows)
 
@@ -377,140 +268,14 @@ func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 	if len(ags) != 2 {
 		t.Fatalf("want 2 parents, got %d", len(ags))
 	}
-	// p1
 	if ags[0].Base.ID != "p1" || ags[0].ChildrenCount != 2 || len(ags[0].Children) != 2 {
 		t.Fatalf("unexpected aggregate for p1: %+v", ags[0])
 	}
-	// p2
 	if ags[1].Base.ID != "p2" || ags[1].ChildrenCount != 1 || len(ags[1].Children) != 1 {
 		t.Fatalf("unexpected aggregate for p2: %+v", ags[1])
 	}
-	// 画像（LONGTEXT文字列）検証
 	if ags[0].Base.ImageData != "IMG_A" || ags[1].Base.ImageData != "IMG_B" {
 		t.Fatalf("unexpected images: %s / %s", ags[0].Base.ImageData, ags[1].Base.ImageData)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_FindIndexAggregates_NoParents(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	parentCols := []string{
-		"id", "name", "image_data", "natural_width", "natural_height",
-		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
-	}
-	mock.ExpectQuery(rx(selectParentsSQL)).
-		WillReturnRows(sqlmock.NewRows(parentCols))
-
-	ags, err := r.FindIndexAggregates(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if len(ags) != 0 {
-		t.Fatalf("want 0 parents, got %d", len(ags))
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_FindIndexAggregates_ParentQueryError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	mock.ExpectQuery(rx(selectParentsSQL)).
-		WillReturnError(assertErr("parent select failed"))
-
-	ags, err := r.FindIndexAggregates(context.Background())
-	if err == nil {
-		t.Fatalf("expected error, got nil; ags=%#v", ags)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_FindIndexAggregates_CountQueryError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	now := time.Now().UTC()
-	parentCols := []string{
-		"id", "name", "image_data", "natural_width", "natural_height",
-		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
-	}
-	parentRows := sqlmock.NewRows(parentCols).
-		AddRow("p1", "Campus A", "A", 4096, 3072, nil, true, 3, now, now, nil).
-		AddRow("p2", "Campus B", "B", 2048, 1536, nil, false, 0, now, now, nil)
-
-	mock.ExpectQuery(rx(selectParentsSQL)).
-		WillReturnRows(parentRows)
-
-	mock.ExpectQuery(rx(`
-		SELECT parent_map_id, COUNT(*)
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN (?,?)
-		GROUP BY parent_map_id
-	`)).
-		WithArgs("p1", "p2").
-		WillReturnError(assertErr("count select failed"))
-
-	ags, err := r.FindIndexAggregates(context.Background())
-	if err == nil {
-		t.Fatalf("expected error, got nil; ags=%#v", ags)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_FindIndexAggregates_ChildQueryError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	now := time.Now().UTC()
-	parentCols := []string{
-		"id", "name", "image_data", "natural_width", "natural_height",
-		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
-	}
-	parentRows := sqlmock.NewRows(parentCols).
-		AddRow("p1", "Campus A", "A", 4096, 3072, nil, true, 3, now, now, nil).
-		AddRow("p2", "Campus B", "B", 2048, 1536, nil, false, 0, now, now, nil)
-
-	mock.ExpectQuery(rx(selectParentsSQL)).
-		WillReturnRows(parentRows)
-
-	mock.ExpectQuery(rx(`
-		SELECT parent_map_id, COUNT(*)
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN (?,?)
-		GROUP BY parent_map_id
-	`)).
-		WithArgs("p1", "p2").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"parent_map_id", "count"}).
-				AddRow("p1", 2).
-				AddRow("p2", 1),
-		)
-
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id
-		FROM maps
-		WHERE deleted_at IS NULL
-		  AND parent_map_id IN (?,?)
-		ORDER BY name ASC
-	`)).
-		WithArgs("p1", "p2").
-		WillReturnError(assertErr("children select failed"))
-
-	ags, err := r.FindIndexAggregates(context.Background())
-	if err == nil {
-		t.Fatalf("expected error, got nil; ags=%#v", ags)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
@@ -536,27 +301,20 @@ func TestMapRepository_FindMapResponseByID_OK(t *testing.T) {
 		id, "Campus 2025", "RAWIMG", 4096, 3072,
 		nil, true, 3, now, now, nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
-	// 子一覧（COALESCE(name,'')）
+	// 子一覧
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("map_201", "1F", false, 0).
 		AddRow("map_202", "2F", false, 0)
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(selectChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(childRows)
 
@@ -598,7 +356,7 @@ func TestMapRepository_FindMapResponseByID_NoRows(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -614,84 +372,8 @@ func TestMapRepository_FindMapResponseByID_NoRows(t *testing.T) {
 	}
 }
 
-func TestMapRepository_FindMapResponseByID_QueryError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	id := "map_123"
-
-	mock.ExpectQuery(rx(selectOneSQL)).
-		WithArgs(id).
-		WillReturnError(assertErr("select failed"))
-
-	res, err := r.FindMapResponseByID(context.Background(), id)
-	if err == nil {
-		t.Fatalf("expected error, got nil; res=%#v", res)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_FindMapResponseByID_NoChildren(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	id := "map_123"
-	now := time.Now().UTC()
-
-	mainCols := []string{
-		"id", "name", "image_data", "natural_width", "natural_height",
-		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
-	}
-	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Empty Child Map", "X", 1024, 768,
-		nil, false, 0, now, now, nil,
-	)
-	mock.ExpectQuery(rx(selectOneSQL)).
-		WithArgs(id).
-		WillReturnRows(mainRow)
-
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
-		WithArgs(id).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-
-	// 子一覧=0行（COALESCE(name,'')）
-	childCols := []string{"id", "name", "has_floors", "floor_count"}
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
-		WithArgs(id).
-		WillReturnRows(sqlmock.NewRows(childCols))
-
-	res, err := r.FindMapResponseByID(context.Background(), id)
-	if err != nil {
-		t.Fatalf("FindMapResponseByID returned err: %v", err)
-	}
-	if res == nil {
-		t.Fatalf("FindMapResponseByID returned nil")
-	}
-	if res.ChildrenCount != 0 || len(res.Children) != 0 {
-		t.Fatalf("expected no children; got count=%d len=%d", res.ChildrenCount, len(res.Children))
-	}
-	if res.HasFloors || res.FloorCount != 0 {
-		t.Fatalf("unexpected floors flags: hasFloors=%v floorCount=%d", res.HasFloors, res.FloorCount)
-	}
-	if res.ImageData != "X" {
-		t.Fatalf("unexpected image: %s", res.ImageData)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
 // -----------------------------------------------------------------------------
-// UpdatePartial（PATCH） LONGTEXT対応（image_data は文字列のまま）
+// UpdatePartial（PATCH）
 // -----------------------------------------------------------------------------
 
 func TestMapRepository_UpdatePartial_UpdateSomeFields_OK(t *testing.T) {
@@ -709,15 +391,13 @@ func TestMapRepository_UpdatePartial_UpdateSomeFields_OK(t *testing.T) {
 		id, "Old Name", "OLD", 1024, 768,
 		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	mock.ExpectExec(rx(`
-		UPDATE maps
-		SET name = ?, natural_width = ?, parent_map_id = ?, modified_at = ?
-		WHERE id = ? AND deleted_at IS NULL
-	`)).
+	// 更新：name, natural_width, parent_map_id, modified_at
+	updateSQL := "UPDATE maps SET name = ?, natural_width = ?, parent_map_id = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL"
+	mock.ExpectExec(updateSQL).
 		WithArgs("New Campus", 2048, "parent_1", sqlmock.AnyArg(), id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -725,23 +405,16 @@ func TestMapRepository_UpdatePartial_UpdateSomeFields_OK(t *testing.T) {
 		id, "New Campus", "OLD", 2048, 768,
 		"parent_1", false, 0, now.Add(-time.Hour), now.Add(time.Minute), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(afterRow)
 
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(selectChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(childCols))
 
@@ -784,15 +457,12 @@ func TestMapRepository_UpdatePartial_ClearParentToNULL_OK(t *testing.T) {
 		id, "Bldg", "IMG", 3000, 2000,
 		"parent_old", true, 5, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	mock.ExpectExec(rx(`
-		UPDATE maps
-		SET parent_map_id = NULL, modified_at = ?
-		WHERE id = ? AND deleted_at IS NULL
-	`)).
+	updateSQL := "UPDATE maps SET parent_map_id = NULL, modified_at = ? WHERE id = ? AND deleted_at IS NULL"
+	mock.ExpectExec(updateSQL).
 		WithArgs(sqlmock.AnyArg(), id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -800,28 +470,20 @@ func TestMapRepository_UpdatePartial_ClearParentToNULL_OK(t *testing.T) {
 		id, "Bldg", "IMG", 3000, 2000,
 		nil, true, 5, now.Add(-time.Hour), now.Add(time.Minute), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(afterRow)
 
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
-	`)).
+	mock.ExpectQuery(countChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
-	mock.ExpectQuery(rx(`
-		SELECT id, COALESCE(name, ''), has_floors, floor_count
-		FROM maps
-		WHERE parent_map_id = ? AND deleted_at IS NULL
-		ORDER BY name
-	`)).
+	mock.ExpectQuery(selectChildrenSQL).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(childCols))
 
 	req := &repository.MapUpdateRequest{
-		// JSON null を想定（Value="" で NULL 解釈）
 		ParentMapID: repository.OptionalString{Set: true, Value: ""},
 	}
 
@@ -855,7 +517,7 @@ func TestMapRepository_UpdatePartial_NoChange_NoUpdate(t *testing.T) {
 		id, "Same", "IMG", 1000, 800,
 		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(rx(selectOneSQL)).
+	mock.ExpectQuery(selectOneSQL).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
@@ -871,78 +533,13 @@ func TestMapRepository_UpdatePartial_NoChange_NoUpdate(t *testing.T) {
 	if got.ImageData != "IMG" {
 		t.Fatalf("unexpected image: %s", got.ImageData)
 	}
-	// UPDATE/再読込無し
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_UpdatePartial_NotFound(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	id := "missing"
-
-	mainCols := []string{
-		"id", "name", "image_data", "natural_width", "natural_height",
-		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
-	}
-	mock.ExpectQuery(rx(selectOneSQL)).
-		WithArgs(id).
-		WillReturnRows(sqlmock.NewRows(mainCols))
-
-	req := &repository.MapUpdateRequest{Name: repository.OptionalString{Set: true, Value: "X"}}
-
-	got, err := r.UpdatePartial(context.Background(), id, req)
-	if err == nil {
-		t.Fatalf("expected error, got nil; res=%#v", got)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_UpdatePartial_UpdateExecError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	id := "map_err"
-	now := time.Now().UTC()
-
-	mainCols := []string{
-		"id", "name", "image_data", "natural_width", "natural_height",
-		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
-	}
-	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Old", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
-	)
-	mock.ExpectQuery(rx(selectOneSQL)).
-		WithArgs(id).
-		WillReturnRows(mainRow)
-
-	mock.ExpectExec(rx(`
-		UPDATE maps
-		SET name = ?, modified_at = ?
-		WHERE id = ? AND deleted_at IS NULL
-	`)).
-		WithArgs("New", sqlmock.AnyArg(), id).
-		WillReturnError(assertErr("update failed"))
-
-	req := &repository.MapUpdateRequest{
-		Name: repository.OptionalString{Set: true, Value: "New"},
-	}
-
-	got, err := r.UpdatePartial(context.Background(), id, req)
-	if err == nil {
-		t.Fatalf("expected exec error, got nil; res=%#v", got)
-	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 
 // -----------------------------------------------------------------------------
-// DeleteCascade（DELETE）
+// DeleteCascade
 // -----------------------------------------------------------------------------
 
 func TestMapRepository_DeleteCascade_OK(t *testing.T) {
@@ -953,46 +550,15 @@ func TestMapRepository_DeleteCascade_OK(t *testing.T) {
 
 	mock.ExpectBegin()
 
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
+	mock.ExpectQuery(deleteExistsSQL).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE p FROM pins p
-		JOIN submaps sm ON p.map_id = sm.id
-	`)).
+	mock.ExpectExec(deletePinsCTE).
 		WithArgs(rootID).
 		WillReturnResult(sqlmock.NewResult(0, 5))
 
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE m FROM maps m
-		JOIN submaps sm ON m.id = sm.id
-	`)).
+	mock.ExpectExec(deleteMapsCTE).
 		WithArgs(rootID).
 		WillReturnResult(sqlmock.NewResult(0, 3))
 
@@ -1004,224 +570,6 @@ func TestMapRepository_DeleteCascade_OK(t *testing.T) {
 	}
 	if mapsDel != 3 || pinsDel != 5 {
 		t.Fatalf("unexpected affected rows: maps=%d pins=%d", mapsDel, pinsDel)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_DeleteCascade_NotFound(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	rootID := "missing"
-
-	mock.ExpectBegin()
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
-		WithArgs(rootID).
-		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
-	mock.ExpectRollback()
-
-	mapsDel, pinsDel, err := r.DeleteCascade(context.Background(), rootID)
-	if err == nil {
-		t.Fatalf("expected sql.ErrNoRows, got nil; maps=%d pins=%d", mapsDel, pinsDel)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_DeleteCascade_ExistSelectError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	rootID := "map_x"
-
-	mock.ExpectBegin()
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
-		WithArgs(rootID).
-		WillReturnError(assertErr("exist select failed"))
-	mock.ExpectRollback()
-
-	_, _, err := r.DeleteCascade(context.Background(), rootID)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_DeleteCascade_DeletePinsError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	rootID := "map_err_pins"
-
-	mock.ExpectBegin()
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
-		WithArgs(rootID).
-		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
-
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE p FROM pins p
-		JOIN submaps sm ON p.map_id = sm.id
-	`)).
-		WithArgs(rootID).
-		WillReturnError(assertErr("delete pins failed"))
-
-	mock.ExpectRollback()
-
-	_, _, err := r.DeleteCascade(context.Background(), rootID)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_DeleteCascade_DeleteMapsError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	rootID := "map_err_maps"
-
-	mock.ExpectBegin()
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
-		WithArgs(rootID).
-		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
-
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE p FROM pins p
-		JOIN submaps sm ON p.map_id = sm.id
-	`)).
-		WithArgs(rootID).
-		WillReturnResult(sqlmock.NewResult(0, 2))
-
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE m FROM maps m
-		JOIN submaps sm ON m.id = sm.id
-	`)).
-		WithArgs(rootID).
-		WillReturnError(assertErr("delete maps failed"))
-
-	mock.ExpectRollback()
-
-	_, _, err := r.DeleteCascade(context.Background(), rootID)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestMapRepository_DeleteCascade_CommitError(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	rootID := "map_commit_err"
-
-	mock.ExpectBegin()
-	mock.ExpectQuery(rx(`
-		SELECT COUNT(*)
-		FROM maps
-		WHERE id = ? AND deleted_at IS NULL
-		LIMIT 1
-	`)).
-		WithArgs(rootID).
-		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
-
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE p FROM pins p
-		JOIN submaps sm ON p.map_id = sm.id
-	`)).
-		WithArgs(rootID).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-
-	mock.ExpectExec(rx(`
-		WITH RECURSIVE submaps AS (
-			SELECT id
-			FROM maps
-			WHERE id = ? AND deleted_at IS NULL
-			UNION ALL
-			SELECT m.id
-			FROM maps m
-			JOIN submaps s ON m.parent_map_id = s.id
-			WHERE m.deleted_at IS NULL
-		)
-		DELETE m FROM maps m
-		JOIN submaps sm ON m.id = sm.id
-	`)).
-		WithArgs(rootID).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-
-	mock.ExpectCommit().WillReturnError(assertErr("commit failed"))
-
-	_, _, err := r.DeleteCascade(context.Background(), rootID)
-	if err == nil {
-		t.Fatalf("expected commit error, got nil")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)

--- a/services/nutfesmap-api/tests/repository/map_test.go
+++ b/services/nutfesmap-api/tests/repository/map_test.go
@@ -34,7 +34,8 @@ const countChildrenSQL = "SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND 
 
 const selectChildrenSQL = "SELECT id, COALESCE(name, ''), has_floors, floor_count FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL ORDER BY name"
 
-const rootExistLockSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL FOR UPDATE"
+// 実装の CreateEmptyMapTx は「parent_map_id IS NULL」を付けない形で存在チェックしている
+const rootExistLockSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at IS NULL FOR UPDATE"
 
 const insertMapSQL = "INSERT INTO maps (id, name, image_data, natural_width, natural_height, parent_map_id, has_floors, floor_count, created_at, modified_at) VALUES (?,?,?,?,?,?,?,?,?,?)"
 
@@ -49,6 +50,45 @@ const deleteExistsSQL = "SELECT COUNT(*) FROM maps WHERE id = ? AND deleted_at I
 const deletePinsCTE = "WITH RECURSIVE submaps AS (SELECT id FROM maps WHERE id = ? AND deleted_at IS NULL UNION ALL SELECT m.id FROM maps m JOIN submaps s ON m.parent_map_id = s.id WHERE m.deleted_at IS NULL) DELETE p FROM pins p JOIN submaps sm ON p.map_id = sm.id"
 
 const deleteMapsCTE = "WITH RECURSIVE submaps AS (SELECT id FROM maps WHERE id = ? AND deleted_at IS NULL UNION ALL SELECT m.id FROM maps m JOIN submaps s ON m.parent_map_id = s.id WHERE m.deleted_at IS NULL) DELETE m FROM maps m JOIN submaps sm ON m.id = sm.id"
+
+// FindFloorStackByAnyID が floors を読む際のクエリ（実装のインデント・改行そのまま）
+const floorsOfRootSQL = `
+		SELECT
+		  id, COALESCE(name, ''), COALESCE(image_data, ''),
+		  COALESCE(natural_width, 0), COALESCE(natural_height, 0),
+		  parent_map_id, has_floors, floor_count, created_at, modified_at
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY created_at ASC, id ASC
+	`
+
+// DeleteTopFloorByIndex で anyID -> root 解決に使うロック付クエリ
+const parentResolveLockSQL = `
+		SELECT parent_map_id FROM maps WHERE id = ? AND deleted_at IS NULL FOR UPDATE
+	`
+
+// DeleteTopFloorByIndex で root の floor_count をロック取得
+const rootFloorCountLockSQL = `
+		SELECT floor_count FROM maps
+		WHERE id = ? AND parent_map_id IS NULL AND deleted_at IS NULL
+		FOR UPDATE
+	`
+
+// DeleteTopFloorByIndex で “最上階（created_at ASC の floorIndex 件目）” を取得
+const selectNthFloorSQL = `
+		SELECT id
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY created_at ASC, id ASC
+		 LIMIT 1 OFFSET ?
+	`
+
+// DeleteTopFloorByIndex の更新（UPDATE maps ...）
+const decRootFloorSQL = `
+		UPDATE maps
+		   SET floor_count = ?, has_floors = ?, modified_at = ?
+		 WHERE id = ? AND deleted_at IS NULL
+	`
 
 // -----------------------------------------------------------------------------
 // CreateByRequest（/maps POST, /maps/{id}/floors POST の実体）
@@ -123,7 +163,7 @@ func TestMapRepository_CreateByRequest_ParentNotFound_Rollback(t *testing.T) {
 
 	mock.ExpectBegin()
 
-	// 親 root 無し
+	// 親 root 無し（0件）
 	mock.ExpectQuery(rootExistLockSQL).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
@@ -133,7 +173,6 @@ func TestMapRepository_CreateByRequest_ParentNotFound_Rollback(t *testing.T) {
 	if err := r.CreateByRequest(context.Background(), newID, &repository.MapCreateRequest{ParentMapID: &rootID}); err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
@@ -570,6 +609,344 @@ func TestMapRepository_DeleteCascade_OK(t *testing.T) {
 	}
 	if mapsDel != 3 || pinsDel != 5 {
 		t.Fatalf("unexpected affected rows: maps=%d pins=%d", mapsDel, pinsDel)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// FindFloorStackByAnyID（root指定）
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_FindFloorStackByAnyID_AsRoot_OK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	rootID := "root_A"
+
+	// 1) anyID=root の aggregate
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	// 1) anyID=root の aggregate
+	rootRow1 := sqlmock.NewRows(mainCols).AddRow(
+		rootID, "講義棟エリア", "IMG", 3000, 2000, nil, true, 3, now, now, nil,
+	)
+	mock.ExpectQuery(selectOneSQL).WithArgs(rootID).WillReturnRows(rootRow1)
+	mock.ExpectQuery(countChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(selectChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// 2) root の aggregate（再読込） ← ★ここを新しい Rows にする
+	rootRow2 := sqlmock.NewRows(mainCols).AddRow(
+		rootID, "講義棟エリア", "IMG", 3000, 2000, nil, true, 3, now, now, nil,
+	)
+	mock.ExpectQuery(selectOneSQL).WithArgs(rootID).WillReturnRows(rootRow2)
+	mock.ExpectQuery(countChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(selectChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// 3) floors（created_at ASC）
+	floorCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at",
+	}
+	floorRows := sqlmock.NewRows(floorCols).
+		AddRow("f1", "1F", "", 0, 0, rootID, false, 0, now.Add(-3*time.Hour), now.Add(-3*time.Hour)).
+		AddRow("f2", "2F", "", 0, 0, rootID, false, 0, now.Add(-2*time.Hour), now.Add(-2*time.Hour)).
+		AddRow("f3", "3F", "", 0, 0, rootID, false, 0, now.Add(-1*time.Hour), now.Add(-1*time.Hour))
+	mock.ExpectQuery(floorsOfRootSQL).WithArgs(rootID).WillReturnRows(floorRows)
+
+	got, err := r.FindFloorStackByAnyID(context.Background(), rootID)
+	if err != nil {
+		t.Fatalf("FindFloorStackByAnyID(root) err: %v", err)
+	}
+	if got == nil || got.RootMapID != rootID || got.FloorCount != 3 || len(got.Items) != 3 {
+		t.Fatalf("unexpected stack: %#v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// FindFloorStackByAnyID（floor指定→親rootへ解決）
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_FindFloorStackByAnyID_AsFloor_OK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	rootID := "root_A"
+	floorID := "f2"
+
+	// 1) anyID=floor の aggregate（親あり）
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	floorRow := sqlmock.NewRows(mainCols).AddRow(
+		floorID, "2F", "", 0, 0, rootID, false, 0, now, now, nil,
+	)
+	mock.ExpectQuery(selectOneSQL).WithArgs(floorID).WillReturnRows(floorRow)
+	mock.ExpectQuery(countChildrenSQL).WithArgs(floorID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(selectChildrenSQL).WithArgs(floorID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// 2) root の aggregate
+	rootRow := sqlmock.NewRows(mainCols).AddRow(
+		rootID, "講義棟エリア", "IMG", 3000, 2000, nil, true, 3, now, now, nil,
+	)
+	mock.ExpectQuery(selectOneSQL).WithArgs(rootID).WillReturnRows(rootRow)
+	mock.ExpectQuery(countChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(selectChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// 3) floors 一覧
+	floorCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at",
+	}
+	floorRows := sqlmock.NewRows(floorCols).
+		AddRow("f1", "1F", "", 0, 0, rootID, false, 0, now.Add(-3*time.Hour), now.Add(-3*time.Hour)).
+		AddRow("f2", "2F", "", 0, 0, rootID, false, 0, now.Add(-2*time.Hour), now.Add(-2*time.Hour)).
+		AddRow("f3", "3F", "", 0, 0, rootID, false, 0, now.Add(-1*time.Hour), now.Add(-1*time.Hour))
+	mock.ExpectQuery(floorsOfRootSQL).WithArgs(rootID).WillReturnRows(floorRows)
+
+	got, err := r.FindFloorStackByAnyID(context.Background(), floorID)
+	if err != nil {
+		t.Fatalf("FindFloorStackByAnyID(floor) err: %v", err)
+	}
+	if got == nil || got.RootMapID != rootID || got.FloorCount != 3 {
+		t.Fatalf("unexpected stack: %#v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// FindFloorStackByAnyID（フロア無し）
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_FindFloorStackByAnyID_NoFloors_OK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	rootID := "root_empty"
+
+	// 1) anyID=root の aggregate
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	// 1) anyID=root の aggregate
+	rootRow1 := sqlmock.NewRows(mainCols).AddRow(
+		rootID, "屋外エリア", "IMG", 2000, 1500, nil, false, 0, now, now, nil,
+	)
+	mock.ExpectQuery(selectOneSQL).WithArgs(rootID).WillReturnRows(rootRow1)
+	mock.ExpectQuery(countChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(selectChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// 2) root aggregate（同じ root を再取得） ← ★新しい Rows
+	rootRow2 := sqlmock.NewRows(mainCols).AddRow(
+		rootID, "屋外エリア", "IMG", 2000, 1500, nil, false, 0, now, now, nil,
+	)
+	mock.ExpectQuery(selectOneSQL).WithArgs(rootID).WillReturnRows(rootRow2)
+	mock.ExpectQuery(countChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(selectChildrenSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "has_floors", "floor_count"}))
+
+	// 3) floors は 0 件
+	floorCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at",
+	}
+	mock.ExpectQuery(floorsOfRootSQL).WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows(floorCols))
+
+	got, err := r.FindFloorStackByAnyID(context.Background(), rootID)
+	if err != nil {
+		t.Fatalf("FindFloorStackByAnyID(root) err: %v", err)
+	}
+	if got == nil || got.RootMapID != rootID || got.FloorCount != 0 || len(got.Items) != 0 {
+		t.Fatalf("unexpected stack: %#v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// DeleteTopFloorByIndex（最上階OK）
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_DeleteTopFloorByIndex_TopOK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "root_A"
+
+	mock.ExpectBegin()
+
+	// anyID=root → parent 解決（NULL）
+	mock.ExpectQuery(parentResolveLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"parent_map_id"}).AddRow(nil))
+
+	// root の floor_count=3 をロック取得
+	mock.ExpectQuery(rootFloorCountLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"floor_count"}).AddRow(3))
+
+	// 最上階 index=3 → OFFSET=2 で id 取得
+	mock.ExpectQuery(selectNthFloorSQL).
+		WithArgs(rootID, 2).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("f3"))
+
+	// pins 削除 → map 削除
+	mock.ExpectExec("DELETE FROM pins WHERE map_id = ?").
+		WithArgs("f3").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("DELETE FROM maps WHERE id = ?").
+		WithArgs("f3").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// root の集約更新（2, true）と modified_at
+	mock.ExpectExec(decRootFloorSQL).
+		WithArgs(2, true, sqlmock.AnyArg(), rootID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectCommit()
+
+	if err := r.DeleteTopFloorByIndex(context.Background(), rootID, 3); err != nil {
+		t.Fatalf("DeleteTopFloorByIndex returned err: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// DeleteTopFloorByIndex（最上階以外 → エラー）
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_DeleteTopFloorByIndex_NotTop_Error(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "root_A"
+
+	mock.ExpectBegin()
+
+	// anyID=root → parent 解決（NULL）
+	mock.ExpectQuery(parentResolveLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"parent_map_id"}).AddRow(nil))
+
+	// floor_count=3 だが、指定 index=2（最上階ではない）
+	mock.ExpectQuery(rootFloorCountLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"floor_count"}).AddRow(3))
+
+	// トップ以外なのでロールバック
+	mock.ExpectRollback()
+
+	if err := r.DeleteTopFloorByIndex(context.Background(), rootID, 2); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// DeleteTopFloorByIndex（floor指定→親root解決）
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_DeleteTopFloorByIndex_FromFloor_TopOK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "root_A"
+	floorID := "f3" // anyID が floor のケース
+
+	mock.ExpectBegin()
+
+	// anyID=floor → parent 解決で root を取得
+	mock.ExpectQuery(parentResolveLockSQL).
+		WithArgs(floorID).
+		WillReturnRows(sqlmock.NewRows([]string{"parent_map_id"}).AddRow(rootID))
+
+	// root の floor_count=3 をロック取得
+	mock.ExpectQuery(rootFloorCountLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"floor_count"}).AddRow(3))
+
+	// 最上階 index=3 → OFFSET=2
+	mock.ExpectQuery(selectNthFloorSQL).
+		WithArgs(rootID, 2).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("f3"))
+
+	mock.ExpectExec("DELETE FROM pins WHERE map_id = ?").
+		WithArgs("f3").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM maps WHERE id = ?").
+		WithArgs("f3").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(decRootFloorSQL).
+		WithArgs(2, true, sqlmock.AnyArg(), rootID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectCommit()
+
+	if err := r.DeleteTopFloorByIndex(context.Background(), floorID, 3); err != nil {
+		t.Fatalf("DeleteTopFloorByIndex(floor) err: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// DeleteTopFloorByIndex（フロア無し → エラー）
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_DeleteTopFloorByIndex_NoFloors_Error(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	rootID := "root_empty"
+
+	mock.ExpectBegin()
+
+	// anyID=root → parent 解決（NULL）
+	mock.ExpectQuery(parentResolveLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"parent_map_id"}).AddRow(nil))
+
+	// floor_count=0
+	mock.ExpectQuery(rootFloorCountLockSQL).
+		WithArgs(rootID).
+		WillReturnRows(sqlmock.NewRows([]string{"floor_count"}).AddRow(0))
+
+	// ロールバック
+	mock.ExpectRollback()
+
+	if err := r.DeleteTopFloorByIndex(context.Background(), rootID, 1); err == nil {
+		t.Fatalf("expected error, got nil")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)

--- a/services/nutfesmap-api/tests/repository/map_test.go
+++ b/services/nutfesmap-api/tests/repository/map_test.go
@@ -450,6 +450,207 @@ func TestMapRepository_FindIndexAggregates_ChildQueryError(t *testing.T) {
 	}
 }
 
+func TestMapRepository_FindMapResponseByID_OK(t *testing.T) {
+	repo, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_123"
+	now := time.Now().UTC()
+
+	// 1) 本体
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "Campus 2025", "iVBORw0K...", 4096, 3072,
+		nil, true, 3, now, now, nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// 2) 子件数
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	// 3) 子一覧
+	childCols := []string{"id", "name", "has_floors", "floor_count"}
+	childRows := sqlmock.NewRows(childCols).
+		AddRow("map_201", "1F", false, 0).
+		AddRow("map_202", "2F", false, 0)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, has_floors, floor_count
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY name
+	`)).
+		WithArgs(id).
+		WillReturnRows(childRows)
+
+	// Act
+	res, err := repo.FindMapResponseByID(context.Background(), id)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("FindMapResponseByID returned err: %v", err)
+	}
+	if res == nil {
+		t.Fatalf("FindMapResponseByID returned nil")
+	}
+	if res.ID != id ||
+		res.Name != "Campus 2025" ||
+		res.ImageData != "iVBORw0K..." ||
+		res.NaturalWidth != 4096 ||
+		res.NaturalHeight != 3072 ||
+		res.ParentMapID != nil ||
+		!res.HasFloors ||
+		res.FloorCount != 3 {
+		t.Fatalf("unexpected base fields: %+v", res)
+	}
+	if res.ChildrenCount != 2 || len(res.Children) != 2 {
+		t.Fatalf("unexpected children meta: count=%d len=%d", res.ChildrenCount, len(res.Children))
+	}
+	if res.Children[0].ID != "map_201" || res.Children[0].Name != "1F" {
+		t.Fatalf("unexpected first child: %+v", res.Children[0])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_FindMapResponseByID_NoRows(t *testing.T) {
+	repo, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_not_found"
+
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	// 0行（= sql.ErrNoRows）
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows(mainCols))
+
+	res, err := repo.FindMapResponseByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected nil, got: %#v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_FindMapResponseByID_QueryError(t *testing.T) {
+	repo, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_123"
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnError(assertErr("select failed"))
+
+	res, err := repo.FindMapResponseByID(context.Background(), id)
+	if err == nil {
+		t.Fatalf("expected error, got nil; res=%#v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_FindMapResponseByID_NoChildren(t *testing.T) {
+	repo, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_123"
+	now := time.Now().UTC()
+
+	// 1) 本体
+	mainCols := []string{
+		"id", "name", "image_data", "natural_width", "natural_height",
+		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
+	}
+	mainRow := sqlmock.NewRows(mainCols).AddRow(
+		id, "Campus 2025", "iVBORw0K...", 4096, 3072,
+		nil, false, 0, now, now, nil,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, image_data, natural_width, natural_height,
+		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
+		  FROM maps
+		 WHERE id = ? AND deleted_at IS NULL
+		 LIMIT 1
+	`)).
+		WithArgs(id).
+		WillReturnRows(mainRow)
+
+	// 2) 子件数=0
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// 3) 子一覧=0行
+	childCols := []string{"id", "name", "has_floors", "floor_count"}
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, name, has_floors, floor_count
+		  FROM maps
+		 WHERE parent_map_id = ? AND deleted_at IS NULL
+		 ORDER BY name
+	`)).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows(childCols))
+
+	// Act
+	res, err := repo.FindMapResponseByID(context.Background(), id)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("FindMapResponseByID returned err: %v", err)
+	}
+	if res == nil {
+		t.Fatalf("FindMapResponseByID returned nil")
+	}
+	if res.ChildrenCount != 0 || len(res.Children) != 0 {
+		t.Fatalf("expected no children; got count=%d len=%d", res.ChildrenCount, len(res.Children))
+	}
+	if res.HasFloors || res.FloorCount != 0 {
+		t.Fatalf("unexpected floors flags: hasFloors=%v floorCount=%d", res.HasFloors, res.FloorCount)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 // --- helpers ---
 
 // assertErr はテスト内で分かりやすい固定エラーを作る小道具

--- a/services/nutfesmap-api/tests/repository/map_test.go
+++ b/services/nutfesmap-api/tests/repository/map_test.go
@@ -3,6 +3,7 @@ package repository_test
 import (
 	"context"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 
 // --- helpers ---
 
-// newMock は MapRepository と sqlmock をまとめて返す
 func newMock(t *testing.T) (*repository.MapRepository, sqlmock.Sqlmock, func()) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -25,46 +25,115 @@ func newMock(t *testing.T) (*repository.MapRepository, sqlmock.Sqlmock, func()) 
 	return r, mock, cleanup
 }
 
-// assertErr はテスト内で分かりやすい固定エラーを作る小道具
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }
 
-// --- Insert ---
+// 改行/複数空白を \s+ に畳み、正規表現として安全にマッチできるようにする
+func rx(s string) string {
+	s = strings.TrimSpace(s)
+	s = regexp.QuoteMeta(s)
+	// 改行/タブ/スペースの差異を吸収
+	s = strings.ReplaceAll(s, "\\\n", "\\s+")
+	s = strings.ReplaceAll(s, "\\t", "\\s+")
+	s = strings.ReplaceAll(s, "\\  ", "\\s+")
+	s = strings.ReplaceAll(s, "\\ ", "\\s+")
+	return s
+}
 
-func TestMapRepository_Insert_OK(t *testing.T) {
+// -----------------------------------------------------------------------------
+// CreateEmpty（空マップ作成：ゼロ値を明示挿入） LONGTEXT対応
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_CreateEmpty_NoParent_OK(t *testing.T) {
 	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
-	// Arrange
-	m := &model.Map{
-		ID:            "map_123",
-		Name:          "Campus 2025",
-		ImageData:     "iVBORw0K...",
-		NaturalWidth:  4096,
-		NaturalHeight: 3072,
-		ParentMapID:   nil,
-		HasFloors:     true,
-		FloorCount:    3,
-	}
+	id := "map_empty_1"
 
-	// Execの引数のうち created_at / modified_at は time.Now().UTC() なので AnyArg() で受ける
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height,
-			parent_map_id, has_floors, floor_count, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?,?,?)
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
 	`)).
-		WithArgs(
-			m.ID, m.Name, m.ImageData, m.NaturalWidth, m.NaturalHeight,
-			m.ParentMapID, m.HasFloors, m.FloorCount, sqlmock.AnyArg(), sqlmock.AnyArg(),
-		).
+		WithArgs(id, "", nil, 0, 0, nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	// Act
-	err := r.Insert(context.Background(), m)
+	if err := r.CreateEmpty(context.Background(), id, nil); err != nil {
+		t.Fatalf("CreateEmpty returned err: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
 
-	// Assert
+func TestMapRepository_CreateEmpty_WithParent_OK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_empty_2"
+	parent := "parent_1"
+
+	mock.ExpectExec(rx(`
+		INSERT INTO maps (
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
+	`)).
+		WithArgs(id, "", nil, 0, 0, parent, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := r.CreateEmpty(context.Background(), id, &parent); err != nil {
+		t.Fatalf("CreateEmpty returned err: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMapRepository_CreateEmpty_ExecError(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	id := "map_empty_err"
+
+	mock.ExpectExec(rx(`
+		INSERT INTO maps (
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
+	`)).
+		WithArgs(id, "", nil, 0, 0, nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(assertErr("insert failed"))
+
+	if err := r.CreateEmpty(context.Background(), id, nil); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Insert（現在は CreateEmpty と同じゼロ値明示挿入に合わせる） LONGTEXT対応
+// -----------------------------------------------------------------------------
+
+func TestMapRepository_Insert_Minimal_OK(t *testing.T) {
+	r, mock, cleanup := newMock(t)
+	defer cleanup()
+
+	m := &model.Map{
+		ID:          "map_min_1",
+		ParentMapID: nil,
+	}
+
+	mock.ExpectExec(rx(`
+		INSERT INTO maps (
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
+	`)).
+		WithArgs(m.ID, "", nil, 0, 0, nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := r.Insert(context.Background(), m)
 	if err != nil {
 		t.Fatalf("Insert returned err: %v", err)
 	}
@@ -73,30 +142,22 @@ func TestMapRepository_Insert_OK(t *testing.T) {
 	}
 }
 
-func TestMapRepository_Insert_ExecError(t *testing.T) {
+func TestMapRepository_Insert_Minimal_WithParent_ExecError(t *testing.T) {
 	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
+	parent := "parent_x"
 	m := &model.Map{
-		ID:            "map_123",
-		Name:          "Campus 2025",
-		ImageData:     "iVBORw0K...",
-		NaturalWidth:  4096,
-		NaturalHeight: 3072,
-		HasFloors:     false,
-		FloorCount:    0,
+		ID:          "map_min_err",
+		ParentMapID: &parent,
 	}
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		INSERT INTO maps (
-			id, name, image_data, natural_width, natural_height,
-			parent_map_id, has_floors, floor_count, created_at, modified_at
-		) VALUES (?,?,?,?,?,?,?,?,?,?)
+			id, name, image_data, natural_width, natural_height, parent_map_id, created_at, modified_at
+		) VALUES (?,?,?,?,?,?,?,?)
 	`)).
-		WithArgs(
-			m.ID, m.Name, m.ImageData, m.NaturalWidth, m.NaturalHeight,
-			m.ParentMapID, m.HasFloors, m.FloorCount, sqlmock.AnyArg(), sqlmock.AnyArg(),
-		).
+		WithArgs(m.ID, "", nil, 0, 0, parent, sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnError(assertErr("insert failed"))
 
 	err := r.Insert(context.Background(), m)
@@ -108,58 +169,92 @@ func TestMapRepository_Insert_ExecError(t *testing.T) {
 	}
 }
 
-// --- FindAggregate ---
+// -----------------------------------------------------------------------------
+// SQL 断片（実装に合わせて COALESCE(image_data,'') を使用）
+// -----------------------------------------------------------------------------
+
+const selectOneSQL = `
+SELECT
+  id,
+  COALESCE(name, ''),
+  COALESCE(image_data, ''),
+  COALESCE(natural_width, 0),
+  COALESCE(natural_height, 0),
+  parent_map_id,
+  has_floors,
+  floor_count,
+  created_at,
+  modified_at,
+  deleted_at
+FROM maps
+WHERE id = ? AND deleted_at IS NULL
+LIMIT 1
+`
+
+const selectParentsSQL = `
+SELECT
+  id,
+  COALESCE(name, ''),
+  COALESCE(image_data, ''),
+  COALESCE(natural_width, 0),
+  COALESCE(natural_height, 0),
+  parent_map_id,
+  has_floors,
+  floor_count,
+  created_at,
+  modified_at,
+  deleted_at
+FROM maps
+WHERE parent_map_id IS NULL
+  AND deleted_at IS NULL
+ORDER BY created_at DESC
+`
+
+// -----------------------------------------------------------------------------
+// FindAggregate
+// -----------------------------------------------------------------------------
 
 func TestMapRepository_FindAggregate_OK(t *testing.T) {
 	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
 	id := "map_123"
-	// 1) 本体行
+	// 1) 本体行（image_data は LONGTEXT 文字列）
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	now := time.Now().UTC()
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Campus 2025", "iVBORw0K...", 4096, 3072,
+		id, "Campus 2025", "IMGPNG", 4096, 3072,
 		nil, true, 3, now, now, nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
 	// 2) 子件数
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
-	// 3) 子一覧
+	// 3) 子一覧（COALESCE(name,'')）
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("map_201", "1F", false, 0).
 		AddRow("map_202", "2F", false, 0)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).
 		WillReturnRows(childRows)
 
-	// Act
 	agg, err := r.FindAggregate(context.Background(), id)
-
-	// Assert
 	if err != nil {
 		t.Fatalf("FindAggregate returned err: %v", err)
 	}
@@ -168,6 +263,10 @@ func TestMapRepository_FindAggregate_OK(t *testing.T) {
 	}
 	if agg.Base.ID != id || agg.ChildrenCount != 2 || len(agg.Children) != 2 {
 		t.Fatalf("unexpected aggregate: %#v", agg)
+	}
+	// LONGTEXT はそのまま返ってくる（base64 変換なし）
+	if agg.Base.ImageData != "IMGPNG" {
+		t.Fatalf("unexpected image_data: %s", agg.Base.ImageData)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
@@ -183,14 +282,7 @@ func TestMapRepository_FindAggregate_NoRows(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	// 0行を返す → nil
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -211,13 +303,7 @@ func TestMapRepository_FindAggregate_QueryError(t *testing.T) {
 	defer cleanup()
 
 	id := "map_123"
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnError(assertErr("select failed"))
 
@@ -230,7 +316,9 @@ func TestMapRepository_FindAggregate_QueryError(t *testing.T) {
 	}
 }
 
-// --- FindIndexAggregates ---
+// -----------------------------------------------------------------------------
+// FindIndexAggregates
+// -----------------------------------------------------------------------------
 
 func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 	r, mock, cleanup := newMock(t)
@@ -244,26 +332,19 @@ func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	parentRows := sqlmock.NewRows(parentCols).
-		AddRow("p1", "Campus A", "BASE64A", 4096, 3072, nil, true, 3, now, now, nil).
-		AddRow("p2", "Campus B", "BASE64B", 2048, 1536, nil, false, 0, now, now, nil)
+		AddRow("p1", "Campus A", "IMG_A", 4096, 3072, nil, true, 3, now, now, nil).
+		AddRow("p2", "Campus B", "IMG_B", 2048, 1536, nil, false, 0, now, now, nil)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE parent_map_id IS NULL
-		   AND deleted_at IS NULL
-		 ORDER BY created_at DESC
-	`)).
+	mock.ExpectQuery(rx(selectParentsSQL)).
 		WillReturnRows(parentRows)
 
 	// 2) 子件数（親ごとに集約）
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT parent_map_id, COUNT(*)
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN (?,?)
-		 GROUP BY parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN (?,?)
+		GROUP BY parent_map_id
 	`)).
 		WithArgs("p1", "p2").
 		WillReturnRows(
@@ -272,34 +353,30 @@ func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 				AddRow("p2", 1),
 		)
 
-	// 3) 子の軽量一覧（親ID IN で一括）
+	// 3) 子の軽量一覧（COALESCE(name,'')）
 	childCols := []string{"id", "name", "has_floors", "floor_count", "parent_map_id"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("c11", "1F", false, 0, "p1").
 		AddRow("c12", "2F", false, 0, "p1").
 		AddRow("c21", "展示エリア", false, 0, "p2")
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count, parent_map_id
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN (?,?)
-		 ORDER BY name ASC
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN (?,?)
+		ORDER BY name ASC
 	`)).
 		WithArgs("p1", "p2").
 		WillReturnRows(childRows)
 
-	// Act
 	ags, err := r.FindIndexAggregates(context.Background())
-
-	// Assert
 	if err != nil {
 		t.Fatalf("FindIndexAggregates returned err: %v", err)
 	}
 	if len(ags) != 2 {
 		t.Fatalf("want 2 parents, got %d", len(ags))
 	}
-
 	// p1
 	if ags[0].Base.ID != "p1" || ags[0].ChildrenCount != 2 || len(ags[0].Children) != 2 {
 		t.Fatalf("unexpected aggregate for p1: %+v", ags[0])
@@ -308,7 +385,10 @@ func TestMapRepository_FindIndexAggregates_OK(t *testing.T) {
 	if ags[1].Base.ID != "p2" || ags[1].ChildrenCount != 1 || len(ags[1].Children) != 1 {
 		t.Fatalf("unexpected aggregate for p2: %+v", ags[1])
 	}
-
+	// 画像（LONGTEXT文字列）検証
+	if ags[0].Base.ImageData != "IMG_A" || ags[1].Base.ImageData != "IMG_B" {
+		t.Fatalf("unexpected images: %s / %s", ags[0].Base.ImageData, ags[1].Base.ImageData)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
@@ -322,15 +402,8 @@ func TestMapRepository_FindIndexAggregates_NoParents(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	// 親0件
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE parent_map_id IS NULL
-		   AND deleted_at IS NULL
-		 ORDER BY created_at DESC
-	`)).WillReturnRows(sqlmock.NewRows(parentCols))
+	mock.ExpectQuery(rx(selectParentsSQL)).
+		WillReturnRows(sqlmock.NewRows(parentCols))
 
 	ags, err := r.FindIndexAggregates(context.Background())
 	if err != nil {
@@ -348,14 +421,8 @@ func TestMapRepository_FindIndexAggregates_ParentQueryError(t *testing.T) {
 	r, mock, cleanup := newMock(t)
 	defer cleanup()
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE parent_map_id IS NULL
-		   AND deleted_at IS NULL
-		 ORDER BY created_at DESC
-	`)).WillReturnError(assertErr("parent select failed"))
+	mock.ExpectQuery(rx(selectParentsSQL)).
+		WillReturnError(assertErr("parent select failed"))
 
 	ags, err := r.FindIndexAggregates(context.Background())
 	if err == nil {
@@ -376,24 +443,18 @@ func TestMapRepository_FindIndexAggregates_CountQueryError(t *testing.T) {
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	parentRows := sqlmock.NewRows(parentCols).
-		AddRow("p1", "Campus A", "BASE64A", 4096, 3072, nil, true, 3, now, now, nil).
-		AddRow("p2", "Campus B", "BASE64B", 2048, 1536, nil, false, 0, now, now, nil)
+		AddRow("p1", "Campus A", "A", 4096, 3072, nil, true, 3, now, now, nil).
+		AddRow("p2", "Campus B", "B", 2048, 1536, nil, false, 0, now, now, nil)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE parent_map_id IS NULL
-		   AND deleted_at IS NULL
-		 ORDER BY created_at DESC
-	`)).WillReturnRows(parentRows)
+	mock.ExpectQuery(rx(selectParentsSQL)).
+		WillReturnRows(parentRows)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT parent_map_id, COUNT(*)
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN (?,?)
-		 GROUP BY parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN (?,?)
+		GROUP BY parent_map_id
 	`)).
 		WithArgs("p1", "p2").
 		WillReturnError(assertErr("count select failed"))
@@ -417,24 +478,18 @@ func TestMapRepository_FindIndexAggregates_ChildQueryError(t *testing.T) {
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	parentRows := sqlmock.NewRows(parentCols).
-		AddRow("p1", "Campus A", "BASE64A", 4096, 3072, nil, true, 3, now, now, nil).
-		AddRow("p2", "Campus B", "BASE64B", 2048, 1536, nil, false, 0, now, now, nil)
+		AddRow("p1", "Campus A", "A", 4096, 3072, nil, true, 3, now, now, nil).
+		AddRow("p2", "Campus B", "B", 2048, 1536, nil, false, 0, now, now, nil)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE parent_map_id IS NULL
-		   AND deleted_at IS NULL
-		 ORDER BY created_at DESC
-	`)).WillReturnRows(parentRows)
+	mock.ExpectQuery(rx(selectParentsSQL)).
+		WillReturnRows(parentRows)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT parent_map_id, COUNT(*)
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN (?,?)
-		 GROUP BY parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN (?,?)
+		GROUP BY parent_map_id
 	`)).
 		WithArgs("p1", "p2").
 		WillReturnRows(
@@ -443,12 +498,12 @@ func TestMapRepository_FindIndexAggregates_ChildQueryError(t *testing.T) {
 				AddRow("p2", 1),
 		)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count, parent_map_id
-		  FROM maps
-		 WHERE deleted_at IS NULL
-		   AND parent_map_id IN (?,?)
-		 ORDER BY name ASC
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count, parent_map_id
+		FROM maps
+		WHERE deleted_at IS NULL
+		  AND parent_map_id IN (?,?)
+		ORDER BY name ASC
 	`)).
 		WithArgs("p1", "p2").
 		WillReturnError(assertErr("children select failed"))
@@ -462,7 +517,9 @@ func TestMapRepository_FindIndexAggregates_ChildQueryError(t *testing.T) {
 	}
 }
 
-// --- FindMapResponseByID ---
+// -----------------------------------------------------------------------------
+// FindMapResponseByID
+// -----------------------------------------------------------------------------
 
 func TestMapRepository_FindMapResponseByID_OK(t *testing.T) {
 	r, mock, cleanup := newMock(t)
@@ -471,50 +528,39 @@ func TestMapRepository_FindMapResponseByID_OK(t *testing.T) {
 	id := "map_123"
 	now := time.Now().UTC()
 
-	// 1) 本体
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Campus 2025", "iVBORw0K...", 4096, 3072,
+		id, "Campus 2025", "RAWIMG", 4096, 3072,
 		nil, true, 3, now, now, nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	// 2) 子件数
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
-	// 3) 子一覧
+	// 子一覧（COALESCE(name,'')）
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
 	childRows := sqlmock.NewRows(childCols).
 		AddRow("map_201", "1F", false, 0).
 		AddRow("map_202", "2F", false, 0)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).
 		WillReturnRows(childRows)
 
-	// Act
 	res, err := r.FindMapResponseByID(context.Background(), id)
-
-	// Assert
 	if err != nil {
 		t.Fatalf("FindMapResponseByID returned err: %v", err)
 	}
@@ -523,7 +569,7 @@ func TestMapRepository_FindMapResponseByID_OK(t *testing.T) {
 	}
 	if res.ID != id ||
 		res.Name != "Campus 2025" ||
-		res.ImageData != "iVBORw0K..." ||
+		res.ImageData != "RAWIMG" ||
 		res.NaturalWidth != 4096 ||
 		res.NaturalHeight != 3072 ||
 		res.ParentMapID != nil ||
@@ -552,14 +598,7 @@ func TestMapRepository_FindMapResponseByID_NoRows(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	// 0行（= nil）
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -581,13 +620,7 @@ func TestMapRepository_FindMapResponseByID_QueryError(t *testing.T) {
 
 	id := "map_123"
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnError(assertErr("select failed"))
 
@@ -607,47 +640,36 @@ func TestMapRepository_FindMapResponseByID_NoChildren(t *testing.T) {
 	id := "map_123"
 	now := time.Now().UTC()
 
-	// 1) 本体
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Campus 2025", "iVBORw0K...", 4096, 3072,
+		id, "Empty Child Map", "X", 1024, 768,
 		nil, false, 0, now, now, nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	// 2) 子件数=0
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	// 3) 子一覧=0行
+	// 子一覧=0行（COALESCE(name,'')）
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(childCols))
 
-	// Act
 	res, err := r.FindMapResponseByID(context.Background(), id)
-
-	// Assert
 	if err != nil {
 		t.Fatalf("FindMapResponseByID returned err: %v", err)
 	}
@@ -660,12 +682,17 @@ func TestMapRepository_FindMapResponseByID_NoChildren(t *testing.T) {
 	if res.HasFloors || res.FloorCount != 0 {
 		t.Fatalf("unexpected floors flags: hasFloors=%v floorCount=%d", res.HasFloors, res.FloorCount)
 	}
+	if res.ImageData != "X" {
+		t.Fatalf("unexpected image: %s", res.ImageData)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 
-// --- UpdatePartial (PATCH) ---
+// -----------------------------------------------------------------------------
+// UpdatePartial（PATCH） LONGTEXT対応（image_data は文字列のまま）
+// -----------------------------------------------------------------------------
 
 func TestMapRepository_UpdatePartial_UpdateSomeFields_OK(t *testing.T) {
 	r, mock, cleanup := newMock(t)
@@ -674,85 +701,68 @@ func TestMapRepository_UpdatePartial_UpdateSomeFields_OK(t *testing.T) {
 	id := "map_123"
 	now := time.Now().UTC()
 
-	// 現在値（更新前）
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Old Name", "BASE64_OLD", 1024, 768,
+		id, "Old Name", "OLD", 1024, 768,
 		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	// 期待: name, natural_width, parent_map_id, has_floors, floor_count を更新 + modified_at
-	mock.ExpectExec(regexp.QuoteMeta(`
-		UPDATE maps SET name = ?, natural_width = ?, parent_map_id = ?, has_floors = ?, floor_count = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	mock.ExpectExec(rx(`
+		UPDATE maps
+		SET name = ?, natural_width = ?, parent_map_id = ?, modified_at = ?
+		WHERE id = ? AND deleted_at IS NULL
 	`)).
-		WithArgs("New Campus", 2048, "parent_1", true, 2, sqlmock.AnyArg(), id).
+		WithArgs("New Campus", 2048, "parent_1", sqlmock.AnyArg(), id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	// 更新後の再取得（FindMapResponseByID）
 	afterRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "New Campus", "BASE64_OLD", 2048, 768,
-		"parent_1", true, 2, now.Add(-time.Hour), now.Add(time.Minute), nil,
+		id, "New Campus", "OLD", 2048, 768,
+		"parent_1", false, 0, now.Add(-time.Hour), now.Add(time.Minute), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(afterRow)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(childCols))
 
-	// リクエスト
 	req := &repository.MapUpdateRequest{
 		Name:         repository.OptionalString{Set: true, Value: "New Campus"},
 		NaturalWidth: repository.OptionalInt{Set: true, Value: 2048},
-		// naturalHeight は未指定（据置）
-		ParentMapID: repository.OptionalString{Set: true, Value: "parent_1"},
-		HasFloors:   repository.OptionalBool{Set: true, Value: true},
-		FloorCount:  repository.OptionalInt{Set: true, Value: 2},
+		ParentMapID:  repository.OptionalString{Set: true, Value: "parent_1"},
 	}
 
-	// Act
 	got, err := r.UpdatePartial(context.Background(), id, req)
-
-	// Assert
 	if err != nil {
 		t.Fatalf("UpdatePartial returned err: %v", err)
 	}
-	if got == nil || got.ID != id || got.Name != "New Campus" || got.NaturalWidth != 2048 || !got.HasFloors || got.FloorCount != 2 {
+	if got == nil || got.ID != id || got.Name != "New Campus" || got.NaturalWidth != 2048 {
 		t.Fatalf("unexpected updated response: %+v", got)
 	}
 	if got.ParentMapID == nil || *got.ParentMapID != "parent_1" {
 		t.Fatalf("expected parent_map_id=parent_1, got: %+v", got.ParentMapID)
+	}
+	if got.ImageData != "OLD" {
+		t.Fatalf("unexpected image after update: %s", got.ImageData)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
@@ -766,68 +776,53 @@ func TestMapRepository_UpdatePartial_ClearParentToNULL_OK(t *testing.T) {
 	id := "map_456"
 	now := time.Now().UTC()
 
-	// 現在は親つき・階層あり
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Bldg", "BASE64", 3000, 2000,
+		id, "Bldg", "IMG", 3000, 2000,
 		"parent_old", true, 5, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	// 期待: parent_map_id を NULL に、has_floors=false に伴い floor_count=0 へ正規化
-	mock.ExpectExec(regexp.QuoteMeta(`
-		UPDATE maps SET parent_map_id = NULL, has_floors = ?, floor_count = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	mock.ExpectExec(rx(`
+		UPDATE maps
+		SET parent_map_id = NULL, modified_at = ?
+		WHERE id = ? AND deleted_at IS NULL
 	`)).
-		WithArgs(false, 0, sqlmock.AnyArg(), id).
+		WithArgs(sqlmock.AnyArg(), id).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	// 更新後の再取得
 	afterRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "Bldg", "BASE64", 3000, 2000,
-		nil, false, 0, now.Add(-time.Hour), now.Add(time.Minute), nil,
+		id, "Bldg", "IMG", 3000, 2000,
+		nil, true, 5, now.Add(-time.Hour), now.Add(time.Minute), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(afterRow)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*) FROM maps WHERE parent_map_id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
 	childCols := []string{"id", "name", "has_floors", "floor_count"}
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, has_floors, floor_count
-		  FROM maps
-		 WHERE parent_map_id = ? AND deleted_at IS NULL
-		 ORDER BY name
+	mock.ExpectQuery(rx(`
+		SELECT id, COALESCE(name, ''), has_floors, floor_count
+		FROM maps
+		WHERE parent_map_id = ? AND deleted_at IS NULL
+		ORDER BY name
 	`)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(childCols))
 
 	req := &repository.MapUpdateRequest{
-		// JSONの null を想定：Value="" で NULL に解釈
+		// JSON null を想定（Value="" で NULL 解釈）
 		ParentMapID: repository.OptionalString{Set: true, Value: ""},
-		HasFloors:   repository.OptionalBool{Set: true, Value: false},
-		// FloorCount 未指定でも false に正規化され 0 になる
 	}
 
 	got, err := r.UpdatePartial(context.Background(), id, req)
@@ -837,8 +832,8 @@ func TestMapRepository_UpdatePartial_ClearParentToNULL_OK(t *testing.T) {
 	if got.ParentMapID != nil {
 		t.Fatalf("expected parent_map_id=NULL, got: %+v", got.ParentMapID)
 	}
-	if got.HasFloors || got.FloorCount != 0 {
-		t.Fatalf("expected hasFloors=false & floorCount=0; got hasFloors=%v floorCount=%d", got.HasFloors, got.FloorCount)
+	if got.ImageData != "IMG" {
+		t.Fatalf("unexpected image: %s", got.ImageData)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
@@ -852,7 +847,6 @@ func TestMapRepository_UpdatePartial_NoChange_NoUpdate(t *testing.T) {
 	id := "map_same"
 	now := time.Now().UTC()
 
-	// 現在値
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
@@ -861,30 +855,23 @@ func TestMapRepository_UpdatePartial_NoChange_NoUpdate(t *testing.T) {
 		id, "Same", "IMG", 1000, 800,
 		nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	// リクエストは全フィールド未指定（=変更なし）
 	req := &repository.MapUpdateRequest{}
 
-	// Act
 	got, err := r.UpdatePartial(context.Background(), id, req)
-
-	// Assert: UPDATE は発行されず、そのまま現在値を詰め替えて返る
 	if err != nil {
 		t.Fatalf("UpdatePartial returned err: %v", err)
 	}
 	if got == nil || got.ID != id || got.Name != "Same" || got.NaturalWidth != 1000 || got.NaturalHeight != 800 {
 		t.Fatalf("unexpected response for no-change patch: %+v", got)
 	}
-	// ここでは FindMapResponseByID を呼ばない実装なので、追加のクエリ期待は無し
+	if got.ImageData != "IMG" {
+		t.Fatalf("unexpected image: %s", got.ImageData)
+	}
+	// UPDATE/再読込無し
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
@@ -900,14 +887,7 @@ func TestMapRepository_UpdatePartial_NotFound(t *testing.T) {
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
 	}
-	// 0行 -> sql.ErrNoRows 想定で nil を返す
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows(mainCols))
 
@@ -922,47 +902,6 @@ func TestMapRepository_UpdatePartial_NotFound(t *testing.T) {
 	}
 }
 
-func TestMapRepository_UpdatePartial_ValidationError_Floors(t *testing.T) {
-	r, mock, cleanup := newMock(t)
-	defer cleanup()
-
-	id := "map_v"
-	now := time.Now().UTC()
-
-	// 現在値（has_floors=false, floor_count=0）
-	mainCols := []string{
-		"id", "name", "image_data", "natural_width", "natural_height",
-		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
-	}
-	mainRow := sqlmock.NewRows(mainCols).AddRow(
-		id, "X", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
-	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
-		WithArgs(id).
-		WillReturnRows(mainRow)
-
-	// リクエスト: hasFloors=true だが floorCount=0 -> バリデーションエラー
-	req := &repository.MapUpdateRequest{
-		HasFloors:  repository.OptionalBool{Set: true, Value: true},
-		FloorCount: repository.OptionalInt{Set: true, Value: 0},
-	}
-
-	got, err := r.UpdatePartial(context.Background(), id, req)
-	if err == nil {
-		t.Fatalf("expected validation error, got nil; res=%#v", got)
-	}
-	// UPDATE は走らないのでここで終了
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
 func TestMapRepository_UpdatePartial_UpdateExecError(t *testing.T) {
 	r, mock, cleanup := newMock(t)
 	defer cleanup()
@@ -970,7 +909,6 @@ func TestMapRepository_UpdatePartial_UpdateExecError(t *testing.T) {
 	id := "map_err"
 	now := time.Now().UTC()
 
-	// 現在値
 	mainCols := []string{
 		"id", "name", "image_data", "natural_width", "natural_height",
 		"parent_map_id", "has_floors", "floor_count", "created_at", "modified_at", "deleted_at",
@@ -978,19 +916,14 @@ func TestMapRepository_UpdatePartial_UpdateExecError(t *testing.T) {
 	mainRow := sqlmock.NewRows(mainCols).AddRow(
 		id, "Old", "IMG", 100, 100, nil, false, 0, now.Add(-time.Hour), now.Add(-time.Hour), nil,
 	)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, name, image_data, natural_width, natural_height,
-		       parent_map_id, has_floors, floor_count, created_at, modified_at, deleted_at
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
-	`)).
+	mock.ExpectQuery(rx(selectOneSQL)).
 		WithArgs(id).
 		WillReturnRows(mainRow)
 
-	// UPDATE でエラー
-	mock.ExpectExec(regexp.QuoteMeta(`
-		UPDATE maps SET name = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL
+	mock.ExpectExec(rx(`
+		UPDATE maps
+		SET name = ?, modified_at = ?
+		WHERE id = ? AND deleted_at IS NULL
 	`)).
 		WithArgs("New", sqlmock.AnyArg(), id).
 		WillReturnError(assertErr("update failed"))
@@ -1008,7 +941,9 @@ func TestMapRepository_UpdatePartial_UpdateExecError(t *testing.T) {
 	}
 }
 
-// --- DeleteCascade (DELETE) ---
+// -----------------------------------------------------------------------------
+// DeleteCascade（DELETE）
+// -----------------------------------------------------------------------------
 
 func TestMapRepository_DeleteCascade_OK(t *testing.T) {
 	r, mock, cleanup := newMock(t)
@@ -1016,56 +951,51 @@ func TestMapRepository_DeleteCascade_OK(t *testing.T) {
 
 	rootID := "map_root"
 
-	// Tx begin
 	mock.ExpectBegin()
 
-	// 1) 存在確認: COUNT(*)=1
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	// 2) pins 削除（再帰CTE）
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE p FROM pins p
 		JOIN submaps sm ON p.map_id = sm.id
 	`)).
 		WithArgs(rootID).
-		WillReturnResult(sqlmock.NewResult(0, 5)) // pins 5件削除
+		WillReturnResult(sqlmock.NewResult(0, 5))
 
-	// 3) maps 削除（再帰CTE）
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE m FROM maps m
 		JOIN submaps sm ON m.id = sm.id
 	`)).
 		WithArgs(rootID).
-		WillReturnResult(sqlmock.NewResult(0, 3)) // maps 3件削除（root+子2など想定）
+		WillReturnResult(sqlmock.NewResult(0, 3))
 
-	// commit
 	mock.ExpectCommit()
 
 	mapsDel, pinsDel, err := r.DeleteCascade(context.Background(), rootID)
@@ -1075,7 +1005,6 @@ func TestMapRepository_DeleteCascade_OK(t *testing.T) {
 	if mapsDel != 3 || pinsDel != 5 {
 		t.Fatalf("unexpected affected rows: maps=%d pins=%d", mapsDel, pinsDel)
 	}
-
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
@@ -1088,11 +1017,11 @@ func TestMapRepository_DeleteCascade_NotFound(t *testing.T) {
 	rootID := "missing"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
@@ -1114,11 +1043,11 @@ func TestMapRepository_DeleteCascade_ExistSelectError(t *testing.T) {
 	rootID := "map_x"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(rootID).
 		WillReturnError(assertErr("exist select failed"))
@@ -1140,25 +1069,25 @@ func TestMapRepository_DeleteCascade_DeletePinsError(t *testing.T) {
 	rootID := "map_err_pins"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE p FROM pins p
 		JOIN submaps sm ON p.map_id = sm.id
@@ -1184,25 +1113,25 @@ func TestMapRepository_DeleteCascade_DeleteMapsError(t *testing.T) {
 	rootID := "map_err_maps"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE p FROM pins p
 		JOIN submaps sm ON p.map_id = sm.id
@@ -1210,16 +1139,16 @@ func TestMapRepository_DeleteCascade_DeleteMapsError(t *testing.T) {
 		WithArgs(rootID).
 		WillReturnResult(sqlmock.NewResult(0, 2))
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE m FROM maps m
 		JOIN submaps sm ON m.id = sm.id
@@ -1245,25 +1174,25 @@ func TestMapRepository_DeleteCascade_CommitError(t *testing.T) {
 	rootID := "map_commit_err"
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`
+	mock.ExpectQuery(rx(`
 		SELECT COUNT(*)
-		  FROM maps
-		 WHERE id = ? AND deleted_at IS NULL
-		 LIMIT 1
+		FROM maps
+		WHERE id = ? AND deleted_at IS NULL
+		LIMIT 1
 	`)).
 		WithArgs(rootID).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE p FROM pins p
 		JOIN submaps sm ON p.map_id = sm.id
@@ -1271,16 +1200,16 @@ func TestMapRepository_DeleteCascade_CommitError(t *testing.T) {
 		WithArgs(rootID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	mock.ExpectExec(regexp.QuoteMeta(`
+	mock.ExpectExec(rx(`
 		WITH RECURSIVE submaps AS (
 			SELECT id
-			  FROM maps
-			 WHERE id = ? AND deleted_at IS NULL
+			FROM maps
+			WHERE id = ? AND deleted_at IS NULL
 			UNION ALL
 			SELECT m.id
-			  FROM maps m
-			  JOIN submaps s ON m.parent_map_id = s.id
-			 WHERE m.deleted_at IS NULL
+			FROM maps m
+			JOIN submaps s ON m.parent_map_id = s.id
+			WHERE m.deleted_at IS NULL
 		)
 		DELETE m FROM maps m
 		JOIN submaps sm ON m.id = sm.id


### PR DESCRIPTION
# PR: 地図メタ取得APIの追加（GET /maps/{mapId}）と関連テスト実装

## 対応Issue
- resolve #0

## 概要
- 地図メタ取得API（GET `/maps/{mapId}`）を追加。
- Repository／Handler／Router に必要な追記を行い、単体テスト（repo・handler）を追加。
- 既存 `/maps`（POST）、`/maps/index`（GET）には変更なし（互換維持）。

## 変更点（概要）
- `internal/repository`
  - 追加: `FindMapResponseByID(ctx, id)`  
    - 既存 `FindAggregate` を利用し、DTO（外部契約）へ詰め替えて返却。
- `internal/handlers`
  - 追加: `Show(c echo.Context)`（GET `/maps/:mapId`）  
    - 子は名称昇順へソート。  
    - `ETag: W/"<sha256(ID+ModifiedAt)>"` を付与。
- `internal/config`（ルーティング）
  - 追加: `mapsG.GET("/:mapId", mapH.Show)`
- テスト
  - Repository テスト: 正常系／NoRows／クエリエラー／子0件。
  - Handler テスト: 正常系／404／500／子0件。  
  - 既存 Create/Index テストは維持。

## 新規エンドポイント仕様
- **GET** `/maps/{mapId}`
  - 説明: 指定IDの地図本体と直下の子メタ情報を返す。
  - 認証: 不要（現仕様）
  - ヘッダ: `ETag`（弱い検証子; `ID + ModifiedAt(RFC3339Nano)` を SHA-256）

### 成功レスポンス例（200）
    {
      "id": "map_123",
      "name": "Campus 2025",
      "imageData": "iVBORw0K...",
      "naturalWidth": 4096,
      "naturalHeight": 3072,
      "parentMapId": null,
      "hasFloors": true,
      "floorCount": 3,
      "childrenCount": 2,
      "children": [
        { "id": "map_201", "name": "1F", "hasFloors": false, "floorCount": 0 },
        { "id": "map_202", "name": "2F", "hasFloors": false, "floorCount": 0 }
      ],
      "createdAt": "2025-09-28T09:00:00Z",
      "modifiedAt": "2025-09-28T09:00:00Z"
    }

### エラーレスポンス
- 400: `{"message":"mapId is required"}`
- 404: `{"message":"map not found"}`
- 500: 予期せぬサーバエラー

## 実装ポイント
- **Repository**: `FindMapResponseByID` は `FindAggregate` の結果を `MapResponse` に変換して返却（見つからなければ `(nil, nil)`）。
- **Handler**: `Show` は `:mapId` を取得 → repo 呼び出し → 子を名称昇順で整列 → `ETag` 付与 → 200応答。
- **Router**: 既存 `/maps` グループに `GET "/:mapId"` を追加。
- **削除フラグ**: 全取得系クエリは `deleted_at IS NULL` を維持。

## 動作確認
1) サーバ起動（既存手順）
2) 作成 → 取得
- 作成（POST `/maps`）
  
      curl -sS -X POST http://localhost:8080/maps \
        -H 'Content-Type: application/json' \
        -d '{ "name":"キャンパスマップ2025","imageData":"iVBORw0K...","naturalWidth":4096,"naturalHeight":3072,"hasFloors":true,"floorCount":3 }'

  応答の `id` を控える。
- 取得（GET `/maps/{id}`）

      curl -i http://localhost:8080/maps/<控えたid>

  `ETag` ヘッダが付与されていることを確認。

3) インデックス（GET `/maps/index`）で子が名称昇順で並ぶことを確認。

## テスト
- 実行コマンド

      go test ./...

- 追加テスト一覧
  - Repository
    - `TestMapRepository_FindMapResponseByID_OK`
    - `TestMapRepository_FindMapResponseByID_NoRows`
    - `TestMapRepository_FindMapResponseByID_QueryError`
    - `TestMapRepository_FindMapResponseByID_NoChildren`
  - Handlers
    - `TestMapHandler_Show_OK`
    - `TestMapHandler_Show_NotFound`
    - `TestMapHandler_Show_QueryError`
    - `TestMapHandler_Show_NoChildren`

## 互換性・影響範囲
- 既存APIの破壊的変更なし。ルート追加のみ。

## セキュリティ・パフォーマンス
- 認証不要の公開API（現仕様）。
- N+1 なし（Index は IN 句で一括、Show は単体対象）。
- ETag により将来 304 応答の最適化余地あり。

## 今後の改善候補（別PR）
- `If-None-Match` 対応で 304 応答を返す最適化。
- 階層が深い構造（孫以降）の再帰取得APIの提供。
