### PR TITLE
[add] global.cssでカラー、フォントの定義 (#23)

### DIFF
--- a/services/nutfesmap-web/src/app/globals.css
+++ b/services/nutfesmap-web/src/app/globals.css
@@ -1,26 +1,46 @@
-@import "tailwindcss";
+/* -----------------------------
+  Tailwind 基本読み込み
+----------------------------- */
+@import "tailwindcss/preflight";
+@tailwind utilities;
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+/* -----------------------------
+  基本スタイル
+----------------------------- */
+@layer base {
+  body {
+    font-family: 'Noto Sans JP', sans-serif;
   }
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+/* -----------------------------
+  独自ユーティリティクラス
+----------------------------- */
+@layer utilities {
+  /* テキストカラー */
+  .text-main {
+    color: #A08702;
+  }
+  .text-second {
+    color: #D4C648;
+  }
+  .text-accent {
+    color: #B02F30;
+  }
+  .text-third {
+    color: #492B04;
+  }
+
+  /* 背景カラー */
+  .bg-main {
+    background-color: #FFFEF3;
+  }
+  .bg-planning-details {
+    background-color: #F1E2E2;
+  }
+
+  /* フォント */
+  .font-sans-custom {
+    font-family: 'Noto Sans JP', sans-serif;
+  }
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
  global.cssでカラー、フォントの定義#23

# 概要
<!-- 開発内容の概要を記載 -->
カラーとフォントの定義

# 実装詳細
<!-- 具体的な開発内容を記載 -->
global.cssにカラーとフォントの定義を追加した

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->


# 備考
<!-- 実装していて困った箇所・質問など -->
- classNameでtext-mainとかbg-mainと打つだけで使用できる
    - figmaと同じ
- デフォでnoto sans JPになるようにできてる？
    - なってなかったらfont-sans-customをclassNameに